### PR TITLE
Distinguish topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+doc/.ipynb_checkpoints/arxiv_topic_labelling-checkpoint.ipynb
+topicnaming/.ipynb_checkpoints/llm_wrappers-checkpoint.py
+topicnaming/.ipynb_checkpoints/topic_naming-checkpoint.py
+topicnaming/__pycache__/__init__.cpython-311.pyc
+topicnaming/__pycache__/llm_wrappers.cpython-311.pyc
+topicnaming/__pycache__/topic_naming.cpython-311.pyc
+topicnaming.egg-info/dependency_links.txt
+topicnaming.egg-info/not-zip-safe
+topicnaming.egg-info/PKG-INFO
+topicnaming.egg-info/requires.txt
+topicnaming.egg-info/SOURCES.txt
+topicnaming.egg-info/top_level.txt
+toponymy/__pycache__/__init__.cpython-311.pyc
+toponymy/__pycache__/llm_wrappers.cpython-311.pyc
+toponymy/__pycache__/topic_naming.cpython-311.pyc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-name = topicnaming
-version = 0.3.0
+name = toponymy
+version = 0.1.0
 author = John Healy
 author_email = jchealy@gmail.com
 maintainer = John Healy
@@ -8,7 +8,7 @@ maintainer_email = jchealy@gmail.com
 description = A library for using large language models to name topics 
 long_description = file: README.rst
 keywords = topic modeing, representation, cluster, clustering, large language models, LLM, topic naming
-url = https://github.com/TutteInstitute/topicnaming
+url = https://github.com/TutteInstitute/toponymy
 license = MIT License
 license_files = LICENSE
 classifiers =
@@ -20,7 +20,7 @@ classifiers =
 
 [options]
 zip_safe = False
-packages = topicnaming
+packages = toponymy
 python_requires = >=3.9
 install_requires =
     numpy>=1.21

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -2,6 +2,8 @@ import tokenizers
 import transformers
 import string
 
+from warnings import warn
+
 try:
 
     import llama_cpp
@@ -49,7 +51,7 @@ try:
             if kind == "base_layer":
                 return "\nThe short distinguising topic name is:\n"
             elif kind == "intermediate_layer":
-                return "\nThe short topic name that encompasses the subtopics is:\n"
+                return "\nThe short topic name that encompasses the sub-topics is:\n"
             elif kind == "remedy":
                 return "\nA better and more specific name that still captures the topic of these article titles is:\n"
             else:
@@ -91,16 +93,23 @@ try:
                 )
                 topic_name_info_text = topic_name_info_raw.text
                 topic_name_info = json.loads(topic_name_info_text)
-                result = []
-                for old_name, name_mapping in zip(old_names, topic_name_info):
-                    if old_name.lower() == list(name_mapping.keys())[0].lower():
-                        result.append(list(name_mapping.values()[0]))
-                    else:
-                        result.append(old_name)
-                        
-                return result
-            except:
+            except Exception as e:
+                warn("Failed to generate topic cluster names with Cohere: " + str(e))
                 return old_names
+            
+            result = []
+            for old_name, name_mapping in zip(old_names, topic_name_info):
+                try:
+                    if old_name.lower() == list(name_mapping.keys())[0].lower():
+                        result.append(list(name_mapping.values())[0])
+                    else:
+                        warn(f"Old name {old_name} does not match the new name {list(name_mapping.keys())[0]}")
+                        result.append(list(name_mapping.values())[0]) # use old_name?
+                except:
+                    result.append(old_name)
+                    
+            return result
+
                     
         def tokenize(self, text):
             return self.tokenizer.tokenize(text)
@@ -111,19 +120,19 @@ try:
         def llm_instruction(self, kind="base_layer"):
             if kind == "base_layer":
                 return """
-You are to give a brief (five to ten word) name describing this group and distinguishing it from other nearby groups.
+You are to give a brief (five to ten word) name describing this group.
 The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
 The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
                 """
             elif kind == "intermediate_layer":
                 return """
-You are to give a brief (three to five word) name describing this group of papers and distinguishing it from other nearby groups.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
+You are to give a brief (three to five word) name describing this group of papers.
+The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
 The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
                 """
             elif kind == "remedy":
                 return """
-You are to give a brief (five to ten word) name describing this group of papers that better captures the specific details of this group.
+You are to give a brief (three to ten word) name describing this group of papers that better captures the specific details of this group.
 The topic should be the most specific topic that encompasses the full breadth of sub-topics.
 The response should be in JSON formatted as {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
 """
@@ -195,14 +204,14 @@ try:
         def llm_instruction(self, kind="base_layer"):
             if kind == "base_layer":
                 return """
-You are to give a brief (five to ten word) name describing this group and distinguishing it from other nearby groups.
+You are to give a brief (five to ten word) name describing this group.
 The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
 The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
                 """
             elif kind == "intermediate_layer":
                 return """
-You are to give a brief (three to five word) name describing this group of papers and distinguishing it from other nearby groups.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
+You are to give a brief (three to five word) name describing this group of papers.
+The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
 The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
                 """
             elif kind == "remedy":


### PR DESCRIPTION
A better approach to distinguishing topics. Don't prompt every topic, just name the topics, then cluster and distinguish similar topics collectively with the LLM. You can also use the cluster tree to get a better handle on subtopics, and renaming there as well.