### PR TITLE
Add optional dependencies with 'dev' identifier for testing LLM wrappers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,17 @@ install_requires =
     sentence_transformers
     dataclasses
     tqdm
-    #llama-cpp-python
+
+[options.extras_require]
+dev =
+    black
+    isort
+    pylint
+    pytest
+    anthropic
+    cohere
+    llama-cpp-python
+    openai
 
 # extras_require = {
 #     'gpu':  ['CMAKE_ARGS="-DLLAMA_CUDA=on" pip install llama-cpp-python'],


### PR DESCRIPTION
`pip install toponymy[dev]` will now install the required packages for all the currently supported LLMs. This will support testing them as part of the release pipeline. Other development packages for formatting, linting, and testing are also included.