### PR TITLE
Prompt templates

### DIFF
--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -7,7 +7,7 @@ import tokenizers
 import transformers
 
 _GET_TOPIC_NAME_REGEX = r'\{\s*"topic_name":\s*.*?, "topic_specificity":\s*\d+\.\d+\s*\}'
-_GET_TOPIC_CLUSTER_NAMES_REGEX = r'\{\s*"topic_names":\s*.*?, "topic_specificity": .*?\}'
+_GET_TOPIC_CLUSTER_NAMES_REGEX = r'\{\s*"new_topic_name_mapping":\s*.*?, "topic_specificities": .*?\}'
 
 try:
 
@@ -46,18 +46,6 @@ try:
             except:
                 return old_names
 
-        def llm_instruction(self, kind="base_layer"):
-            if kind == "base_layer":
-                return "\nThe short distinguising topic name is:\n"
-            elif kind == "intermediate_layer":
-                return "\nThe short topic name that encompasses the sub-topics is:\n"
-            elif kind == "remedy":
-                return "\nA better and more specific name that still captures the topic of these article titles is:\n"
-            else:
-                raise ValueError(
-                    f"Invalid llm_imnstruction kind; should be one of 'base_layer', 'intermediate_layer', or 'remedy' not '{kind}'"
-                )
-
 except ImportError:
     pass
 
@@ -94,30 +82,7 @@ try:
                 return result
             except:
                 return old_names
-            
-        def llm_instruction(self, kind="base_layer"):
-            if kind == "base_layer":
-                return """
-You are to give a brief (five to ten word) name describing this group.
-The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
-The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "intermediate_layer":
-                return """
-You are to give a brief (three to five word) name describing this group of papers.
-The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
-The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "remedy":
-                return """
-You are to give a brief (three to ten word) name describing this group of papers that better captures the specific details of this group.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
-The response should be in JSON formatted as {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-"""
-            else:
-                raise ValueError(
-                    f"Invalid llm_imnstruction kind; should be one of 'base_layer', 'intermediate_layer', or 'remedy' not '{kind}'"
-                )
+
 
 except ImportError:
     pass
@@ -170,29 +135,6 @@ try:
                 warn(f"Failed to generate topic cluster names with Cohere: {e}")
                 return old_names
 
-        def llm_instruction(self, kind="base_layer"):
-            if kind == "base_layer":
-                return """
-You are to give a brief (five to ten word) name describing this group.
-The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
-The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "intermediate_layer":
-                return """
-You are to give a brief (three to five word) name describing this group of papers.
-The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
-The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "remedy":
-                return """
-You are to give a brief (three to ten word) name describing this group of papers that better captures the specific details of this group.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
-The response should be in JSON formatted as {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-"""
-            else:
-                raise ValueError(
-                    f"Invalid llm_imnstruction kind; should be one of 'base_layer', 'intermediate_layer', or 'remedy' not '{kind}'"
-                )
 
 except:
     pass
@@ -238,30 +180,6 @@ try:
                 return result
             except:
                 return old_names
-
-        def llm_instruction(self, kind="base_layer"):
-            if kind == "base_layer":
-                return """
-You are to give a brief (five to ten word) name describing this group.
-The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
-The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "intermediate_layer":
-                return """
-You are to give a brief (three to five word) name describing this group of papers.
-The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
-The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "remedy":
-                return """
-You are to give a brief (five to ten word) name describing this group of papers that better captures the specific details of this group.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
-The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-"""
-            else:
-                raise ValueError(
-                    f"Invalid llm_imnstruction kind; should be one of 'base_layer', 'intermediate_layer', or 'remedy' not '{kind}'"
-                )
 
 except:
     pass
@@ -312,30 +230,6 @@ try:
                 return result
             except:
                 return old_names
-
-        def llm_instruction(self, kind="base_layer"):
-            if kind == "base_layer":
-                return """
-You are to give a brief (five to ten word) name describing this group.
-The topic name should be as specific as you can reasonably make it, while still describing the all example texts.
-The response must be **ONLY** JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "intermediate_layer":
-                return """
-You are to give a brief (three to five word) name describing this group of papers.
-The topic should be the most specific topic that encompasses the breadth of sub-topics, with a focus on the major sub-topics.
-The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-                """
-            elif kind == "remedy":
-                return """
-You are to give a brief (five to ten word) name describing this group of papers that better captures the specific details of this group.
-The topic should be the most specific topic that encompasses the full breadth of sub-topics.
-The response should be only JSON with no preamble formatted as {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} where SCORE is a value in the range 0 to 1.
-"""
-            else:
-                raise ValueError(
-                    f"Invalid llm_imnstruction kind; should be one of 'base_layer', 'intermediate_layer', or 'remedy' not '{kind}'"
-                )
 
 except:
     pass

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -40,7 +40,8 @@ try:
                 topic_name_info_text = topic_name_info_raw["choices"][0]["text"]
                 topic_name_info = re.findall(_GET_TOPIC_CLUSTER_NAMES_REGEX, topic_name_info_text)[0]
                 topic_name_info = json.loads(topic_name_info)
-                result = topic_name_info["topic_names"]
+                mapping = topic_name_info["new_topic_name_mapping"]
+                result = [mapping.get(f"{n}. {name}", name) for n, name in enumerate(old_names)]
                 return result
             except:
                 return old_names
@@ -88,7 +89,8 @@ try:
                 topic_name_info_text = topic_name_info_raw[0]["generated_text"][-1]['content']
                 topic_name_info = re.findall(_GET_TOPIC_CLUSTER_NAMES_REGEX, topic_name_info_text)[0]
                 topic_name_info = json.loads(topic_name_info)
-                result = topic_name_info["topic_names"]
+                mapping = topic_name_info["new_topic_name_mapping"]
+                result = [mapping.get(f"{n}. {name}", name) for n, name in enumerate(old_names)]
                 return result
             except:
                 return old_names
@@ -161,13 +163,12 @@ try:
                 )
                 topic_name_info_text = topic_name_info_raw.text
                 topic_name_info = json.loads(topic_name_info_text)
+                mapping = topic_name_info["new_topic_name_mapping"]
+                result = [mapping.get(f"{n}. {name}", name) for n, name in enumerate(old_names)]
+                return result
             except Exception as e:
                 warn(f"Failed to generate topic cluster names with Cohere: {e}")
-                print(topic_name_info_text)
                 return old_names
-
-            result = topic_name_info["topic_names"]
-            return result
 
         def llm_instruction(self, kind="base_layer"):
             if kind == "base_layer":
@@ -232,7 +233,8 @@ try:
                 )
                 topic_name_info_text = topic_name_info_raw.content[0].text
                 topic_name_info = json.loads(topic_name_info_text)
-                result = topic_name_info["topic_names"]
+                mapping = topic_name_info["new_topic_name_mapping"]
+                result = [mapping.get(f"{n}. {name}", name) for n, name in enumerate(old_names)]
                 return result
             except:
                 return old_names
@@ -305,7 +307,8 @@ try:
                 )
                 topic_name_info_text = topic_name_info_raw.choices[0].message.content
                 topic_name_info = json.loads(topic_name_info_text)
-                result = topic_name_info["topic_names"]
+                mapping = topic_name_info["new_topic_name_mapping"]
+                result = [mapping.get(f"{n}. {name}", name) for n, name in enumerate(old_names)]
                 return result
             except:
                 return old_names

--- a/toponymy/topic_naming.py
+++ b/toponymy/topic_naming.py
@@ -1418,4 +1418,7 @@ class Toponymy:
                 if unique_name not in unique_names:
                     unique_names[unique_name] = (n, i)
 
-                self.layer_clusters[n][indices] = unique_name
+                if unique_name != "":
+                    self.layer_clusters[n][indices] = unique_name
+                else:
+                    self.layer_clusters[n][indices] = name # If we failed to get a name, keep the old one

--- a/toponymy/topic_naming.py
+++ b/toponymy/topic_naming.py
@@ -1059,11 +1059,8 @@ class Toponymy:
             metric="precomputed",
             linkage="complete",
         )
-        print("Distance threshold", distance_threshold)
         cls.fit(base_layer_topic_distances)
         cluster_sizes = np.bincount(cls.labels_)
-        print("Cluster sizes", np.sort(cluster_sizes)[::-1])
-        print(pd.Series(new_topic_names).value_counts())
         clusters_for_renaming = np.where(cluster_sizes >= 2)[0]
         for c in tqdm(
             clusters_for_renaming,
@@ -1090,7 +1087,7 @@ class Toponymy:
                 for new_topic_name, topic_index in zip(cluster_topic_names, label_indices[i:i+8]):
                     new_topic_names[topic_index] = new_topic_name
 
-        print(pd.Series(new_topic_names).value_counts())
+
         self.base_layer_topics_ = new_topic_names
 
     def fit_base_layer_topics(self):
@@ -1342,69 +1339,6 @@ class Toponymy:
                 document_type=self.document_type,
                 corpus_description=self.corpus_description,
             )
-
-#             prompt = f"There are collections of {self.corpus_description} with somewhat similar auto-generated topic names, all in your field of expertise.\n"
-#             prompt += "Below are the auto-generated topic names, along with some keywords associated to each topic, and sub-topics from the topic area."
-#             for x in label_indices:
-#                 prompt += f"\n\n**{self.topic_name_layers_[layer_id][x]}**\n"
-#                 prompt += (
-#                     "    - keywords: "
-#                     + ", ".join(self.representation_["contrastive"][layer_id][x])
-#                     + "\n"
-#                 )
-#                 # Get tree based subtopics
-#                 tree_subtopics = self.cluster_tree_[(layer_id, x)]
-
-#                 # Subtopics one layer down are major subtopics; two layers down are minor
-#                 major_subtopics = [a[1] for a in tree_subtopics if a[0] == layer_id - 1]
-#                 minor_subtopics = [a[1] for a in tree_subtopics if a[0] == layer_id - 2]
-#                 other_subtopics = [a for a in tree_subtopics if a[0] < layer_id - 2]
-
-#                 if len(major_subtopics) > 0:
-#                     prompt += "\nMajor sub-topics for this group are:\n"
-#                     for subtopic_id in major_subtopics:
-#                         prompt += f'- "{self.topic_name_layers_[layer_id - 1][subtopic_id]}"\n'
-
-#                 if len(minor_subtopics) > 0:
-#                     prompt += "\nMinor sub-topics for this group are:\n"
-#                     for subtopic_id in minor_subtopics:
-#                         prompt += f'- "{self.topic_name_layers_[layer_id - 2][subtopic_id]}"\n'
-
-#                 if len(other_subtopics) > 0:
-#                     prompt += "\nOther sub-topics for this group not included in major or minor sub-topics are:\n"
-#                     for layer_num, subtopic_id in other_subtopics[:max_subtopics]:
-#                         prompt += (
-#                             f'- "{self.topic_name_layers_[layer_num][subtopic_id]}"\n'
-#                         )
-
-#                 if len(tree_subtopics) < max_subtopics:
-#                     # Use the previous layer information to inject knowledge into this cluster.
-#                     prompt += (
-#                         "\nA sampling of detailed sub-topics from the group include:\n"
-#                     )
-#                     for text in previous_layer_topics[x][
-#                         : (max_subtopics - len(tree_subtopics))
-#                     ]:
-#                         prompt += f'- "{text}"\n'
-
-#                 # Add some topical documents if we don't have many subtopics
-#                 if len(tree_subtopics) < max_subtopics:
-#                     prompt += f"    - sample {self.document_type}:\n"
-#                     for text in self.representation_["topical"][0][x][
-#                         : max_subtopics - len(tree_subtopics)
-#                     ]:
-#                         prompt += f'        + "{text}"\n'
-
-#             prompt += "\n\nYou should make use of the relative relationships between these topics as well as the keywords and sub-topic information to generate new topic names."
-#             prompt += "\nStrive to provide the simplest possible topic name (ideally a few words) that distinguishes a given topic from the other topics listed."
-#             prompt += """
-# The response should be formatted as JSON in the format 
-#     {"topic_names": [<NAME1>, <NAME2>, ...], "previous_topic_names": [<OLD_NAME1>, <OLD_NAME2>, ...], topic_specificity": [<SCORE1>, <SCORE2>, ...]}
-# where SCORE is a value in the range 0 to 1.
-# The response must contain only JSON with no preamble and must have one entry for each topic to be renamed.
-#             """
-#             prompt += "The result must contain only JSON with no preamble and must have one entry for each topic to be renamed\n"
-
             cluster_topic_names = self.llm.generate_topic_cluster_names(
                 prompt,
                 [self.topic_name_layers_[layer_id][x] for x in label_indices],

--- a/toponymy/topic_naming.py
+++ b/toponymy/topic_naming.py
@@ -55,6 +55,7 @@ better and more *specific* topic name.
 The response should be only JSON with no preamble formatted as 
   {"topic_name":<NAME>, "less_specific_topic_name":<NAME>, "topic_specificity":<SCORE>} 
 where SCORE is a value in the range 0 to 1.
+The response must contain only JSON with no preamble.
 """
     ),
     "distinguish_base_layer_topics": jinja2.Template(

--- a/toponymy/topic_naming.py
+++ b/toponymy/topic_naming.py
@@ -136,30 +136,30 @@ Below are the auto-generated topic names, along with some keywords associated to
 {% for topic in topics %}
 
 "{{loop.index}}. {{topic}}":
-{% if cluster_keywords[loop.index] %}
- - Keywords for this group include: {{", ".join(cluster_keywords[loop.index])}}
+{% if cluster_keywords[loop.index - 1] %}
+ - Keywords for this group include: {{", ".join(cluster_keywords[loop.index - 1])}}
 {% endif %}
-{%- if cluster_subtopics["major"][loop.index] %}
+{%- if cluster_subtopics["major"][loop.index - 1] %}
  - Major subtopics of this group are: 
-{%- for subtopic in cluster_subtopics["major"][loop.index] %}
+{%- for subtopic in cluster_subtopics["major"][loop.index - 1] %}
       * {{subtopic}}
 {%- endfor %}
 {%- endif %}
-{%- if cluster_subtopics["minor"][loop.index] %}
+{%- if cluster_subtopics["minor"][loop.index - 1] %}
  - Minor subtopics of this group are:
-{%- for subtopic in cluster_subtopics["minor"][loop.index] %}
+{%- for subtopic in cluster_subtopics["minor"][loop.index - 1] %}
       * {{subtopic}}
 {%- endfor %}
 {%- endif %}
-{%- if cluster_subtopics["misc"][loop.index] %}
+{%- if cluster_subtopics["misc"][loop.index - 1] %}
  - Other miscellaneous specific subtopics of this group include:
-{%- for subtopic in cluster_subtopics["misc"][loop.index] %}
+{%- for subtopic in cluster_subtopics["misc"][loop.index - 1] %}
         * {{subtopic}}
 {%- endfor %}
 {%- endif %}
-{%- if cluster_sentences[loop.index] %}
+{%- if cluster_sentences[loop.index - 1] %}
  - Sample {{document_type}} from this group include:
-{%- for sentence in cluster_sentences[loop.index] %}
+{%- for sentence in cluster_sentences[loop.index - 1] %}
       - "{{sentence}}"
 {%- endfor %}
 {%- endif %}
@@ -1316,14 +1316,15 @@ class Toponymy:
 
             tree_subtopics_per_topic = [self.cluster_tree_[(layer_id, x)] for x in label_indices]
             major_subtopics_per_topic = [
-                [a[1] for a in tree_subtopics if a[0] == layer_id - 1] for tree_subtopics in tree_subtopics_per_topic
+                [self.topic_name_layers_[layer_id - 1][a[1]] for a in tree_subtopics if a[0] == layer_id - 1] for tree_subtopics in tree_subtopics_per_topic
             ]
             minor_subtopics_per_topic = [
-                [a[1] for a in tree_subtopics if a[0] == layer_id - 2] for tree_subtopics in tree_subtopics_per_topic
+                [self.topic_name_layers_[layer_id - 2][a[1]] for a in tree_subtopics if a[0] == layer_id - 2] for tree_subtopics in tree_subtopics_per_topic
             ]
             other_subtopics_per_topic = [
                 [a for a in tree_subtopics if a[0] < layer_id - 2] for tree_subtopics in tree_subtopics_per_topic
             ]
+            other_subtopics_per_topic = [[self.topic_name_layers_[a[0]][a[1]] for a in topic] for topic in other_subtopics_per_topic]
 
             prompt = template.render(
                 larger_topic=larger_topic,


### PR DESCRIPTION
Move to using jinja2 templating for prompt construction. This is more flexible and will be easier to edit and maintain in the future -- adding the the templates should be much easier.

This also centralizes the basic prompting with a single template and a "level of detail" specification to adjust how detailed topic names should be. Disambiguation and remedy are the other prompt types. These all should probably get renamed in an upcoming refactor.