### PR TITLE
Add base_url argument to OpenAI wrapper

### DIFF
--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -232,8 +232,8 @@ try:
 
     class OpenAIWrapper:
 
-        def __init__(self, API_KEY, model="gpt-4o-mini", verbose=False):
-            self.llm = openai.OpenAI(api_key=API_KEY)
+        def __init__(self, API_KEY, model="gpt-4o-mini", base_url=None, verbose=False):
+            self.llm = openai.OpenAI(api_key=API_KEY, base_url=base_url)
             self.model = model
             self.verbose = verbose
 


### PR DESCRIPTION
For self hosted models that have the OpenAI API you need to change the base_url so the client can find things properly