### PR TITLE
Exemplar keyphrases refactoring

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,169 @@
+# Trigger a build when there is a push to the main branch or a tag starts with release-
+trigger:
+  branches:
+    include:
+    - main
+  tags:
+    include:
+    - release-*
+
+# Trigger a build when there is a pull request to the main branch
+# Ignore PRs that are just updating the docs
+pr:
+  branches:
+    include:
+    - main
+    exclude:
+    - doc/*
+    - README.rst
+
+parameters:
+  - name: includeReleaseCandidates
+    displayName: "Allow pre-release dependencies"
+    type: boolean
+    default: false
+
+variables:
+  triggeredByPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
+
+stages:
+  - stage: RunAllTests
+    displayName: Run test suite
+    jobs:
+      - job: run_platform_tests
+        strategy:
+          matrix:
+            mac_py39:
+              imageName: 'macOS-latest'
+              python.version: '3.9'
+            linux_py39:
+              imageName: 'ubuntu-latest'
+              python.version: '3.9'
+            windows_py39:
+              imageName: 'windows-latest'
+              python.version: '3.9'
+            mac_py310:
+              imageName: 'macOS-latest'
+              python.version: '3.10'
+            linux_py310:
+              imageName: 'ubuntu-latest'
+              python.version: '3.10'
+            windows_py310:
+              imageName: 'windows-latest'
+              python.version: '3.10'
+            mac_py311:
+              imageName: 'macOS-latest'
+              python.version: '3.11'
+            linux_py311:
+              imageName: 'ubuntu-latest'
+              python.version: '3.11'
+            windows_py311:
+              imageName: 'windows-latest'
+              python.version: '3.11'
+            mac_py312:
+              imageName: 'macOS-latest'
+              python.version: '3.12'
+            linux_py312:
+              imageName: 'ubuntu-latest'
+              python.version: '3.12'
+            windows_py312:
+              imageName: 'windows-latest'
+              python.version: '3.12'
+        pool:
+          vmImage: $(imageName)
+
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
+
+        - script: |
+            python -m pip install --upgrade pip
+          displayName: 'Upgrade pip'
+
+        - script: |
+            pip install -r requirements.txt
+          displayName: 'Install dependencies'
+          condition: ${{ eq(parameters.includeReleaseCandidates, false) }}
+
+        - script: |
+            pip install --pre -r requirements.txt
+          displayName: 'Install dependencies (allow pre-releases)'
+          condition: ${{ eq(parameters.includeReleaseCandidates, true) }}
+
+        - script: |
+            pip install -e .
+            pip install pytest  pytest-azurepipelines
+            pip install pytest-cov
+            pip install coveralls
+          displayName: 'Install package'
+
+        - script: |
+            pytest fast_hdbscan/tests --show-capture=no -v --disable-warnings --junitxml=junit/test-results.xml --cov=fast_hdbscan/ --cov-report=xml --cov-report=html
+          displayName: 'Run tests'
+
+        - bash: |
+            coveralls
+          displayName: 'Publish to coveralls'
+          condition: and(succeeded(), eq(variables.triggeredByPullRequest, false)) # Don't run this for PRs because they can't access pipeline secrets
+          env:
+            COVERALLS_REPO_TOKEN: $(COVERALLS_TOKEN)
+
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFiles: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+            testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
+          condition: succeededOrFailed()
+
+  - stage: BuildPublishArtifact
+    dependsOn: RunAllTests
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/release-'), eq(variables.triggeredByPullRequest, false))
+    jobs:
+      - job: BuildArtifacts
+        displayName: Build source dists and wheels    
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.10'
+          displayName: 'Use Python 3.10'
+
+        - script: |
+            python -m pip install --upgrade pip
+            pip install wheel
+            pip install -r requirements.txt
+          displayName: 'Install dependencies'
+
+        - script: |
+            pip install -e .
+          displayName: 'Install package locally'
+        
+        - script: |
+            python setup.py sdist bdist_wheel
+          displayName: 'Build package'
+
+        - bash: |
+            export PACKAGE_VERSION="$(python setup.py --version)"
+            echo "Package Version: ${PACKAGE_VERSION}"
+            echo "##vso[task.setvariable variable=packageVersionFormatted;]release-${PACKAGE_VERSION}"
+          displayName: 'Get package version'
+
+        - script: |
+            echo "Version in git tag $(Build.SourceBranchName) does not match version derived from setup.py $(packageVersionFormatted)"
+            exit 1
+          displayName: Raise error if version doesnt match tag
+          condition: and(succeeded(), ne(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
+
+        - task: DownloadSecureFile@1
+          name: PYPIRC_CONFIG
+          displayName: 'Download pypirc'
+          inputs:
+            secureFile: 'pypirc'  
+
+        - script: |
+            pip install twine
+            twine upload --repository pypi --config-file $(PYPIRC_CONFIG.secureFilePath) dist/* 
+          displayName: 'Upload to PyPI'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Callable, Any, Optional
+from typing import List, Callable, Any, Optional, Tuple
 import scipy.sparse
 import numpy as np
 import pandas as pd
@@ -414,8 +414,8 @@ class ClusterLayerText(ClusterLayer):
         self,
         object_list: List[str],
         object_vectors: np.ndarray,
-    ) -> List[List[str]]:
-        self.exemplars = diverse_exemplars(
+    ) -> Tuple[List[List[str]], List[List[int]]]:
+        self.exemplar, self.exemplar_indices = diverse_exemplars(
             cluster_label_vector=self.cluster_labels,
             objects=object_list,
             object_vectors=object_vectors,
@@ -426,7 +426,7 @@ class ClusterLayerText(ClusterLayer):
             show_progress_bar=self.show_progress_bar,
         )
 
-        return self.exemplars
+        return self.exemplars, self.exemplar_indices
 
     def make_topic_name_vector(self) -> np.ndarray:
         self.topic_name_vector = np.full(self.cluster_labels.shape[0], "Unlabelled", dtype=object)

--- a/toponymy/exemplar_texts.py
+++ b/toponymy/exemplar_texts.py
@@ -159,3 +159,116 @@ def diverse_exemplars(
             ]
         results.append(chosen_exemplars)
     return results
+
+def diverse_exemplars(
+    cluster_label_vector: np.ndarray,
+    objects: List[str],
+    object_vectors: np.ndarray,
+    centroid_vectors: np.ndarray,
+    n_exemplars: int = 4,
+    diversify_alpha: float = 1.0,
+    object_to_text_function: Callable[[Any], List[str]] = lambda x: x,
+    method: str = "centroid",
+    show_progress_bar: bool = False,
+) -> Tuple[List[List[str]], List[List[int]]]:
+    """Generates a list of exemplar text for each cluster in a cluster layer.
+    These exemplars are selected to be the closest vectors to the cluster centroid while retaining
+    sufficient diversity.
+
+    Parameters
+    ----------
+    cluster_label_vector : np.ndarray
+        A vector of cluster labels for each object.
+    objects : List[str]
+        A list of objects; these are text objects a sample of which are returned as exemplars for each cluster.
+    object_vectors = np.ndarray
+        An ndarray of topic vectors for each object.
+    centroid_vectors : np.ndarray
+        An ndarray of centroid vectors for each cluster.
+    n_exemplars : int, optional
+        The number of exemplars to sample for each cluster, by default 4.
+    diversify_alpha : float, optional
+        The alpha parameter for diversifying the keyphrase selection, by default 1.0.
+    object_to_text_function: Callable[[Any], List[str]]
+        A function which takes an object and returns an exemplar string, by default for strings it is lambda x: x
+    method : str, optional
+        The sampling method for selecting exemplars 'centroid' or 'random', by default it is 'centroid'.
+    show_progress_bar : bool, optional
+        Whether to show a progress bar, by default False.
+
+    Returns
+    -------
+    Tuple[List[List[str]], List[List[int]]]
+        A tuple containing:
+        - A list of lists of exemplar texts for each cluster
+        - A list of lists of indices indicating the position of each exemplar in the original object list
+    """
+    results = []
+    indices = []
+    
+    for cluster_num in tqdm(
+        range(cluster_label_vector.max() + 1),
+        desc="Selecting central exemplars",
+        disable=not show_progress_bar,
+        unit="cluster",
+        leave=False,
+        position=1,
+    ):
+        # Get mask for current cluster
+        cluster_mask = cluster_label_vector == cluster_num
+        cluster_objects = np.array(objects)[cluster_mask]
+        # Store original indices for this cluster
+        original_indices = np.where(cluster_mask)[0]
+        
+        # If there is an empty cluster emit empty lists
+        if len(cluster_objects) == 0:
+            results.append([])
+            indices.append([])
+            continue
+            
+        cluster_object_vectors = object_vectors[cluster_mask]
+
+        if method == "centroid":
+            # Select the central exemplars as the objects to each centroid
+            exemplar_distances = pairwise_distances(
+                centroid_vectors[cluster_num].reshape(1, -1),
+                cluster_object_vectors,
+                metric="cosine",
+            )
+            exemplar_order = np.argsort(exemplar_distances.flatten())
+        elif method == "random":
+            exemplar_order = np.random.permutation(len(cluster_objects))
+        else:
+            raise ValueError(
+                f"method={method} is not a valid selection. Please choose one of (centroid,random)"
+            )
+
+        # We need more exemplars than we want in case we drop some via diversify
+        n_exemplars_to_take = max((n_exemplars * 2), 16)
+        exemplar_candidates = [
+            cluster_objects[i] for i in exemplar_order[:n_exemplars_to_take]
+        ]
+        candidate_vectors = np.asarray(
+            [cluster_object_vectors[i] for i in exemplar_order[:n_exemplars_to_take]]
+        )
+        chosen_indices = diversify(
+            centroid_vectors[cluster_num],
+            candidate_vectors,
+            n_exemplars,
+            max_alpha=diversify_alpha,
+        )[:n_exemplars]
+        
+        if object_to_text_function is None:
+            chosen_exemplars = [exemplar_candidates[i] for i in chosen_indices]
+        else:
+            chosen_exemplars = [
+                object_to_text_function(exemplar_candidates[i]) for i in chosen_indices
+            ]
+            
+        # Map chosen indices back to original object list indices
+        chosen_original_indices = [original_indices[exemplar_order[i]] for i in chosen_indices]
+        
+        results.append(chosen_exemplars)
+        indices.append(chosen_original_indices)
+        
+    return results, indices

--- a/toponymy/exemplar_texts.py
+++ b/toponymy/exemplar_texts.py
@@ -13,7 +13,7 @@ def random_exemplars(
     n_exemplars: int = 4,
     object_to_text_function: Callable[[Any], List[str]] = lambda x: x,
     show_progress_bar: bool = False,
-) -> List[List[str]]:
+) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar texts for each cluster in a cluster layer.
     These exemplars are randomly sampled from each cluster.
 
@@ -33,11 +33,14 @@ def random_exemplars(
 
     Returns
     -------
-    exemplars List[List[str]]
-        A list of lists of exemplar text for each cluster.
+    Tuple[List[List[str]], List[List[int]]]
+        A tuple containing:
+        - A list of lists of exemplar texts for each cluster
+        - A list of lists of indices indicating the position of each exemplar in the original object list
     """
 
     results = []
+    indices = []
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc="Selecting random exemplars",
@@ -46,12 +49,18 @@ def random_exemplars(
         leave=False,
         position=1,
     ):
-        # Grab the vectors associated with the objects in this cluster
-        cluster_objects = np.array(objects)[cluster_label_vector == cluster_num]
-        # If there is an empty cluster emit the empty list of exemplars
+        # Get mask for current cluster
+        cluster_mask = cluster_label_vector == cluster_num
+        cluster_objects = np.array(objects)[cluster_mask]
+        # Store original indices for this cluster
+        original_indices = np.where(cluster_mask)[0]
+        
+        # If there is an empty cluster emit empty lists
         if len(cluster_objects) == 0:
             results.append([])
+            indices.append([])
             continue
+        
         # Randomly permute the index to create a random selection
         exemplar_order = np.random.permutation(len(cluster_objects))[:n_exemplars]
         if object_to_text_function is None:
@@ -60,105 +69,15 @@ def random_exemplars(
             chosen_exemplars = [
                 object_to_text_function(cluster_objects[i]) for i in exemplar_order
             ]
+        
+        # Map chosen indices back to original object list indices
+        chosen_original_indices = [original_indices[i] for i in exemplar_order]
+        
         results.append(chosen_exemplars)
-    return results
+        indices.append(chosen_original_indices)
+        
+    return results, indices
 
-
-def diverse_exemplars(
-    cluster_label_vector: np.ndarray,
-    objects: List[str],
-    object_vectors: np.ndarray,
-    centroid_vectors: np.ndarray,
-    n_exemplars: int = 4,
-    diversify_alpha: float = 1.0,
-    object_to_text_function: Callable[[Any], List[str]] = lambda x: x,
-    method: str = "centroid",
-    show_progress_bar: bool = False,
-) -> List[List[str]]:
-    """Generates a list of exemplar text for each cluster in a cluster layer.
-    These exemplars are selected to be the closest vectors to the cluster centroid while retaining
-    sufficient diversity.
-
-    Parameters
-    ----------
-    cluster_label_vector : np.ndarray
-        A vector of cluster labels for each object.
-    objects : List[str]
-        A list of objects; these are text objects a sample of which are returned as exemplars for each cluster.
-    object_vectors = np.ndarray
-        An ndarray of topic vectors for each object.
-    centroid_vectors : np.ndarray
-        An ndarray of centroid vectors for each cluster.
-    n_exemplars : int, optional
-        The number of exemplars to sample for each cluster, by default 4.
-    diversify_alpha : float, optional
-        The alpha parameter for diversifying the keyphrase selection, by default 1.0.
-    object_to_text_function: Callable[[Any], List[str]]
-        A function which takes an object and returns an exemplar string, by default for strings it is lambda x: x
-    method : str, optional
-        The sampling method for selecting exemplars 'centroid' or 'random', by default it is 'centroid'.
-    show_progress_bar : bool, optional
-        Whether to show a progress bar, by default False.
-
-    Returns
-    -------
-    exemplars List[List[str]]
-        A list of lists of exemplar text for each cluster.
-    """
-    results = []
-    for cluster_num in tqdm(
-        range(cluster_label_vector.max() + 1),
-        desc="Selecting central exemplars",
-        disable=not show_progress_bar,
-        unit="cluster",
-        leave=False,
-        position=1,
-    ):
-        # Grab the vectors associated with the objects in this cluster
-        cluster_objects = np.array(objects)[cluster_label_vector == cluster_num]
-        # If there is an empty cluster emit the empty list of exemplars
-        if len(cluster_objects) == 0:
-            results.append([])
-            continue
-        cluster_object_vectors = object_vectors[cluster_label_vector == cluster_num]
-
-        if method == "centroid":
-            # Select the central exemplars as the objects to each centroid
-            exemplar_distances = pairwise_distances(
-                centroid_vectors[cluster_num].reshape(1, -1),
-                cluster_object_vectors,
-                metric="cosine",
-            )
-            exemplar_order = np.argsort(exemplar_distances.flatten())
-        elif method == "random":
-            exemplar_order = np.random.permutation(len(cluster_objects))
-        else:
-            raise ValueError(
-                f"method={method} is not a valid selection.  Please choose one of (centroid,random)"
-            )
-
-        # We need more exemplars than we want in case we drop some via diversify
-        n_exemplars_to_take = max((n_exemplars * 2), 16)
-        exemplar_candidates = [
-            cluster_objects[i] for i in exemplar_order[: n_exemplars_to_take]
-        ]
-        candidate_vectors = np.asarray(
-            [cluster_object_vectors[i] for i in exemplar_order[: n_exemplars_to_take]]
-        )
-        chosen_indices = diversify(
-            centroid_vectors[cluster_num],
-            candidate_vectors,
-            n_exemplars,
-            max_alpha=diversify_alpha,
-        )[:n_exemplars]
-        if object_to_text_function is None:
-            chosen_exemplars = [exemplar_candidates[i] for i in chosen_indices]
-        else:
-            chosen_exemplars = [
-                object_to_text_function(exemplar_candidates[i]) for i in chosen_indices
-            ]
-        results.append(chosen_exemplars)
-    return results
 
 def diverse_exemplars(
     cluster_label_vector: np.ndarray,

--- a/toponymy/tests/test_exemplar_texts.py
+++ b/toponymy/tests/test_exemplar_texts.py
@@ -37,7 +37,7 @@ def test_random_exemplar(n_exemplars):
 @pytest.mark.parametrize("diversify_alpha", [0.0, 0.5, 1.0])
 @pytest.mark.parametrize("method", ['centroid','random'])
 def test_diverse_exemplar_result_sizes(n_exemplars: Literal[3] | Literal[5], diversify_alpha: float, method: str):
-    exemplar_results = diverse_exemplars(
+    exemplar_results, exemplar_indices = diverse_exemplars(
         cluster_label_vector = CLUSTER_LAYER,
         objects = ALL_TOPIC_OBJECTS,
         object_vectors = TOPIC_VECTORS,
@@ -58,7 +58,7 @@ def test_diverse_exemplar_result_sizes(n_exemplars: Literal[3] | Literal[5], div
 def test_empty_cluster_diverse(method: str):
     new_clustering = CLUSTER_LAYER
     new_clustering[new_clustering==0] = 9
-    exemplar_results = diverse_exemplars(
+    exemplar_results, exemplar_indices = diverse_exemplars(
         cluster_label_vector = new_clustering,
         objects = ALL_TOPIC_OBJECTS,
         object_vectors = TOPIC_VECTORS,
@@ -70,7 +70,7 @@ def test_empty_cluster_diverse(method: str):
 def test_empty_cluster_random():
     new_clustering = CLUSTER_LAYER
     new_clustering[new_clustering==0] = 9
-    exemplar_results = random_exemplars(
+    exemplar_results, exemplar_indices = random_exemplars(
         cluster_label_vector = new_clustering,
         objects = ALL_TOPIC_OBJECTS,
     )


### PR DESCRIPTION
Refactor how keyphrases are generated to support generating keyphrases solely from exemplars when object_to_text_function is not None. This should allow keyphrase generation based on image captioning without the need to run image captioning inference over the entire dataset (just the exemplar objects of the bottom layer which we need to run inference on anyway to create the texts).