### PR TITLE
Add embedding wrappers to allow use of embedding services

### DIFF
--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -7,6 +7,7 @@ anthropic
 cohere
 openai
 azure-ai-inference
+mistral-ai
 numpy>=1.26,<2.0
 transformers
 bm25s

--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -1,0 +1,172 @@
+import numpy as np
+from tqdm.auto import tqdm
+import httpx
+
+from typing import Optional, List
+
+# Cohere
+try:
+    import cohere
+
+    class CohereEmbedder:
+        def __init__(self, api_key, model: str = "embed-multilingual-v3.0", base_url: str = None, httpx_client: Optional[httpx.Client] = None):
+            self.co = cohere.ClientV2(api_key=api_key)
+            self.model = model
+            self.base_url = base_url
+            self.httpx_client = httpx_client
+            self.input_type="search_query" # We will be embedding keyphrases and subtopic names to match against documents
+            self.embedding_types=['float']
+
+        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                response = self.co.embed(texts=texts[i:i+96], model=self.model, input_type=self.input_type, embedding_types=self.embedding_types)
+                result.append(np.asarray(response.embeddings.float_))
+
+            return np.vstack(result)
+    
+except ImportError:
+    pass
+
+# OpenAI
+try:
+    import openai
+
+    class OpenAIEmbedder:
+
+        def __init__(self, api_key, model: str = "text-embedding-3-small", base_url: str = None):
+            self.api_key = api_key
+            self.model = model
+            self.base_url = base_url
+            self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+
+        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                response = self.client.embeddings.create(texts=texts[i:i+96], model=self.model, encoding_format="float")
+                result.append(np.asarray([item.embedding for item in response.data]))       
+
+            return np.vstack(result)
+        
+except ImportError:
+    pass
+
+# Anthropic
+try:
+    import anthropic
+
+    class AnthropicEmbedder:
+        def __init__(self, api_key, model: str = "claude-3-haiku-20240307", base_url: str = None, httpx_client: Optional[httpx.Client] = None):
+            self.client = anthropic.Anthropic(api_key=api_key)
+            self.model = model
+            self.base_url = base_url
+            self.httpx_client = httpx_client
+
+        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                batch = texts[i:i+96]
+                # Anthropic embeddings are done one at a time in the current API
+                batch_embeddings = []
+                for text in tqdm(batch, desc="embedding batch", disable=(not show_progress_bar), leave=False):
+                    response = self.client.embeddings.create(
+                        model=self.model,
+                        input=text,
+                    )
+                    batch_embeddings.append(response.embedding)
+                result.append(np.array(batch_embeddings))
+
+            return np.vstack(result)
+except ImportError:
+    pass
+
+# Microsoft Azure
+try:
+    import azure.ai.inference
+    from azure.core.credentials import AzureKeyCredential
+
+    class AzureAIEmbedder:
+        def __init__(self, api_key: str, endpoint: str, model: str):
+            self.credentials = AzureKeyCredential(api_key)
+            self.client = azure.ai.inference.EmbeddingsClient(endpoint=endpoint, credential=self.credentials)
+            self.model = model
+
+        def encode(self, texts: list, show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                batch = texts[i:i+96]
+                
+                # Call the Azure AI Inference API
+                response = self.client.embed(
+                    model=self.model,
+                    input=batch
+                )
+                
+                # Extract embeddings from the response
+                embeddings = []
+                for embedding_result in response.data:
+                    embeddings.append(embedding_result.embedding)
+                
+                result.append(np.array(embeddings))
+            
+            return np.vstack(result)
+
+except ImportError as e:
+    pass
+
+# Mistral
+try:
+    import mistralai.client
+
+    class MistralEmbedder:
+        def __init__(self, api_key: str, model: str = "mistral-embed"):
+            self.client = mistralai.client.MistralClient(api_key=api_key)
+            self.model = model
+
+        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                response = self.client.embeddings(
+                    model=self.model,
+                    inputs=texts[i:i+96]
+                )
+                result.append(np.array([item.embedding for item in response.data]))
+
+            return np.vstack(result)
+except ImportError:
+    pass
+
+# Voyage AI
+try:
+    import requests
+
+    class VoyageAIEmbedder:
+        def __init__(self, api_key: str, model: str = "voyage-2"):
+            self.api_key = api_key
+            self.model = model
+            self.base_url = "https://api.voyageai.com/v1/embeddings"
+            self.headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json"
+            }
+
+        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+            result = []
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+                response = requests.post(
+                    self.base_url,
+                    headers=self.headers,
+                    json={
+                        "model": self.model,
+                        "input": texts[i:i+96],
+                        "encoding_format": "float"
+                    }
+                )
+                response.raise_for_status()
+                data = response.json()
+                result.append(np.array([item["embedding"] for item in data["data"]]))
+
+            return np.vstack(result)
+except ImportError:
+    pass

--- a/toponymy/tests/test_embedding_wrappers.py
+++ b/toponymy/tests/test_embedding_wrappers.py
@@ -1,0 +1,197 @@
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch
+import sys
+
+# Import your module (assuming it's called embedders.py)
+# If your module has a different name, adjust this import
+sys.path.append('.')
+import toponymy.embedding_wrappers as embedders
+
+class TestCohereEmbedder:
+    @patch('cohere.ClientV2')
+    def test_encode(self, mock_client_v2):
+        # Set up mock response
+        mock_client = MagicMock()
+        mock_client_v2.return_value = mock_client
+        
+        mock_response = MagicMock()
+        mock_response.embeddings.float_ = [[0.1, 0.2], [0.3, 0.4]]
+        mock_client.embed.return_value = mock_response
+        
+        # Create the embedder and call encode
+        embedder = embedders.CohereEmbedder(api_key="fake_key")
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        mock_client.embed.assert_called_once_with(
+            texts=texts, 
+            model="embed-multilingual-v3.0", 
+            input_type="search_query",
+            embedding_types=['float']
+        )
+
+class TestOpenAIEmbedder:
+    @patch('openai.OpenAI')
+    def test_encode(self, mock_openai):
+        # Set up mock response
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        mock_data_item1 = MagicMock()
+        mock_data_item1.embedding = [0.1, 0.2]
+        mock_data_item2 = MagicMock()
+        mock_data_item2.embedding = [0.3, 0.4]
+        
+        mock_response = MagicMock()
+        mock_response.data = [mock_data_item1, mock_data_item2]
+        mock_client.embeddings.create.return_value = mock_response
+        
+        # Create the embedder and call encode
+        embedder = embedders.OpenAIEmbedder(api_key="fake_key")
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        mock_client.embeddings.create.assert_called_once()
+
+class TestAnthropicEmbedder:
+    @patch('anthropic.Anthropic')
+    def test_encode(self, mock_anthropic):
+        # Set up mock response
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        
+        mock_response1 = MagicMock()
+        mock_response1.embedding = [0.1, 0.2]
+        mock_response2 = MagicMock()
+        mock_response2.embedding = [0.3, 0.4]
+        
+        mock_client.embeddings.create.side_effect = [mock_response1, mock_response2]
+        
+        # Create the embedder and call encode
+        embedder = embedders.AnthropicEmbedder(api_key="fake_key")
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        assert mock_client.embeddings.create.call_count == 2
+
+class TestAzureAIEmbedder:
+    @patch('azure.ai.inference.EmbeddingsClient')
+    def test_encode(self, mock_ai_client):
+        # Set up mock response
+        mock_client = MagicMock()
+        mock_ai_client.return_value = mock_client
+        
+        # Create mock embedding results
+        mock_embedding_result1 = MagicMock()
+        mock_embedding_result1.embedding = [0.1, 0.2]
+        mock_embedding_result2 = MagicMock()
+        mock_embedding_result2.embedding = [0.3, 0.4]
+        
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding_result1, mock_embedding_result2]
+        
+        # Configure the mock client to return our mock response
+        mock_client.embed.return_value = mock_response
+        
+        # Create the embedder and call encode
+        embedder = embedders.AzureAIEmbedder(
+            api_key="fake_key", 
+            endpoint="https://fake-endpoint.azure.com/", 
+            model="text-embedding"
+        )
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        mock_client.embed.assert_called_once()
+        # Check that the deployment name was passed correctly
+        args, kwargs = mock_client.embed.call_args
+        assert kwargs["model"] == "text-embedding"
+        # Check that BatchInput was created with correct number of items
+        assert len(kwargs["input"]) == 2
+
+class TestMistralEmbedder:
+    @patch('mistralai.client.MistralClient')
+    def test_encode(self, mock_mistral_client):
+        # Set up mock response
+        mock_client = MagicMock()
+        mock_mistral_client.return_value = mock_client
+        
+        mock_data_item1 = MagicMock()
+        mock_data_item1.embedding = [0.1, 0.2]
+        mock_data_item2 = MagicMock()
+        mock_data_item2.embedding = [0.3, 0.4]
+        
+        mock_response = MagicMock()
+        mock_response.data = [mock_data_item1, mock_data_item2]
+        mock_client.embeddings.return_value = mock_response
+        
+        # Create the embedder and call encode
+        embedder = embedders.MistralEmbedder(api_key="fake_key")
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        mock_client.embeddings.assert_called_once_with(
+            model="mistral-embed",
+            inputs=texts
+        )
+
+class TestVoyageAIEmbedder:
+    @patch('requests.post')
+    def test_encode(self, mock_post):
+        # Set up mock response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"embedding": [0.1, 0.2]},
+                {"embedding": [0.3, 0.4]}
+            ]
+        }
+        mock_post.return_value = mock_response
+        
+        # Create the embedder and call encode
+        embedder = embedders.VoyageAIEmbedder(api_key="fake_key")
+        texts = ["sample text 1", "sample text 2"]
+        result = embedder.encode(texts)
+        
+        # Verify the result
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        np.testing.assert_almost_equal(result, np.array([[0.1, 0.2], [0.3, 0.4]]))
+        
+        # Verify API was called correctly
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["model"] == "voyage-2"
+        assert kwargs["json"]["input"] == texts


### PR DESCRIPTION
Provide tools that can support various embedding services, such as Cohere, OpenAI, Anthropic, Mistral and AzureAI within the Toponymy framework so you can outsource embedding work from your CPU.