### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     dataclasses
     tqdm
     tenacity
+    httpx
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
to fix "ModuleNotFoundError: No module named 'httpx' " error in llm_wrapper.py

please see

![image](https://github.com/user-attachments/assets/88570723-c45f-47c3-ae84-b8891f69a0bc)
