### PR TITLE
Update README.rst to fix numpy issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ should be similar.
 .. code-block:: python
 
     pip install sentence_transformers
+    pip install openai
+    pip install numpy==1.24
 
     from sentence_transformers import SentenceTransformer
     embedding_model = SentenceTransformer("all-MiniLM-L6-v2")


### PR DESCRIPTION
added following so new users can follow the demo smoothly 

pip install openai
pip install numpy==1.24

why numpy == 1.24 ? when above 2, it will get a RuntimeError: Numpy is not available under python 3.11

here is the error I ran into 
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/4036d2ac-0b37-4b7b-827d-1a7812bf390b" />
