### PR TITLE
Topic trees

### DIFF
--- a/toponymy/tests/test_topic_tree.py
+++ b/toponymy/tests/test_topic_tree.py
@@ -46,7 +46,15 @@ def test_topic_tree_string():
         ["Topic A", "Topic B"],
     ]
 
-    result = topic_tree_string_recursion(tree_dict, (3, 0), topics)
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
+
+    result = topic_tree_string_recursion(tree_dict, (3, 0), topics, topic_sizes, n_objects)
+    print(result)
     expected_result = (
         "Topic tree:\n"
         "   - Topic A\n"
@@ -66,7 +74,7 @@ def test_topic_tree_string():
     )
     assert result == expected_result
 
-def test_topic_tree_html():
+def test_topic_tree_string_sizes():
     tree_dict = {
         (3, 0): [(2, 0), (2,1)],
         (2, 0): [(1, 0), (1, 1)],
@@ -83,7 +91,58 @@ def test_topic_tree_html():
         ["Topic A", "Topic B"],
     ]
 
-    result = topic_tree_html(tree_dict, topics)
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
+
+    result = topic_tree_string_recursion(tree_dict, (3, 0), topics, topic_sizes, n_objects, cluster_size=True, cluster_percentage=True)
+    print(result)
+    expected_result = (
+        "Topic tree:\n"
+        "   - Topic A (8 objects) [40.00%]\n"
+        "     - Subtopic A1 (4 objects) [20.00%]\n"
+        "       - Subtopic C1 (2 objects) [10.00%]\n"
+        "       - Subtopic C2 (2 objects) [10.00%]\n"
+        "     - Subtopic A2 (4 objects) [20.00%]\n"
+        "       - Subtopic C3 (2 objects) [10.00%]\n"
+        "       - Subtopic C4 (2 objects) [10.00%]\n"
+        "   - Topic B (12 objects) [60.00%]\n"
+        "     - Subtopic B1 (6 objects) [30.00%]\n"
+        "       - Subtopic C5 (3 objects) [15.00%]\n"
+        "       - Subtopic C6 (3 objects) [15.00%]\n"
+        "     - Subtopic B2 (6 objects) [30.00%]\n"
+        "       - Subtopic C7 (3 objects) [15.00%]\n"
+        "       - Subtopic C8 (3 objects) [15.00%]\n"
+    )
+    assert result == expected_result
+
+def test_topic_tree_html():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
+
+    result = topic_tree_html(tree_dict, topics, topic_sizes, n_objects)
     expected_result = """<div class="topic-tree">
     <style>
         .topic-tree ul {
@@ -233,8 +292,14 @@ def test_topic_tree_html_with_colors():
         ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
         ["Topic A", "Topic B"],
     ]
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
 
-    result = topic_tree_html(tree_dict, topics, variable_color=True)
+    result = topic_tree_html(tree_dict, topics, topic_sizes, n_objects, variable_color=True)
     expected_result = """<div class="topic-tree">
     <style>
         .topic-tree ul {
@@ -383,9 +448,14 @@ def test_topic_tree_html_with_colors_no_weight():
         ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
         ["Topic A", "Topic B"],
     ]
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
 
-    result = topic_tree_html(tree_dict, topics, variable_color=True, variable_weight=False)
-    print(result)
+    result = topic_tree_html(tree_dict, topics, topic_sizes, n_objects, variable_color=True, variable_weight=False)
     expected_result = """<div class="topic-tree">
     <style>
         .topic-tree ul {
@@ -535,8 +605,14 @@ def test_topic_tree_html_no_color_no_weight():
         ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
         ["Topic A", "Topic B"],
     ]
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
 
-    result = topic_tree_html(tree_dict, topics, variable_color=False, variable_weight=False)
+    result = topic_tree_html(tree_dict, topics, topic_sizes, n_objects, variable_color=False, variable_weight=False)
     expected_result = """<div class="topic-tree">
     <style>
         .topic-tree ul {
@@ -685,8 +761,14 @@ def test_topic_tree_class():
         ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
         ["Topic A", "Topic B"],
     ]
+    topic_sizes = [
+        [2, 2, 2, 2, 3, 3, 3, 3],
+        [4, 4, 6, 6],
+        [8, 12],
+    ]
+    n_objects = 20
 
-    tree_instance = TopicTree(tree_dict, topics)
+    tree_instance = TopicTree(tree_dict, topics, topic_sizes=topic_sizes, n_objects=n_objects)
     assert tree_instance.tree == tree_dict
     assert tree_instance.topics == topics
 
@@ -708,7 +790,7 @@ def test_topic_tree_class():
         "       - Subtopic C8\n"
     )
     assert str(tree_instance) == expected_string
-    assert tree_instance._repr_html_() == topic_tree_html(tree_dict, topics)
+    assert tree_instance._repr_html_() == topic_tree_html(tree_dict, topics, topic_sizes, n_objects)
 
 def test_unfitted_toponymy_fails():
     with pytest.raises(NotFittedError, match="This Toponymy instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator."):

--- a/toponymy/tests/test_topic_tree.py
+++ b/toponymy/tests/test_topic_tree.py
@@ -1,0 +1,715 @@
+from toponymy import Toponymy
+from toponymy.clustering import ToponymyClusterer
+from toponymy.keyphrases import KeyphraseBuilder
+from toponymy.llm_wrappers import HuggingFace
+
+from sentence_transformers import SentenceTransformer
+from toponymy.topic_tree import TopicTree, topic_tree_html, topic_tree_string_recursion
+from sklearn.utils.validation import NotFittedError
+
+import pytest
+
+LLM = HuggingFace("Qwen/Qwen2.5-0.5B-Instruct")
+EMBEDDER = SentenceTransformer("all-MiniLM-L6-v2")
+CLUSTERER = ToponymyClusterer(
+    min_samples=5,
+    base_min_cluster_size=4,
+    next_cluster_size_quantile=1.0,
+    min_clusters=4,
+)
+MODEL = Toponymy(
+    LLM,
+    EMBEDDER,
+    CLUSTERER,
+    keyphrase_builder = KeyphraseBuilder(n_jobs=1),
+    object_description = "sentences",
+    corpus_description = "collection of sentences",
+    lowest_detail_level = 0.8,
+    highest_detail_level = 1.0,
+    show_progress_bars=True,
+)
+
+def test_topic_tree_string():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    result = topic_tree_string_recursion(tree_dict, (3, 0), topics)
+    expected_result = (
+        "Topic tree:\n"
+        "   - Topic A\n"
+        "     - Subtopic A1\n"
+        "       - Subtopic C1\n"
+        "       - Subtopic C2\n"
+        "     - Subtopic A2\n"
+        "       - Subtopic C3\n"
+        "       - Subtopic C4\n"
+        "   - Topic B\n"
+        "     - Subtopic B1\n"
+        "       - Subtopic C5\n"
+        "       - Subtopic C6\n"
+        "     - Subtopic B2\n"
+        "       - Subtopic C7\n"
+        "       - Subtopic C8\n"
+    )
+    assert result == expected_result
+
+def test_topic_tree_html():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    result = topic_tree_html(tree_dict, topics)
+    expected_result = """<div class="topic-tree">
+    <style>
+        .topic-tree ul {
+            list-style-type: none;
+            padding-left: 25px;
+            margin-top: 5px;
+        }
+        .topic-tree li {
+            list-style-type: none;
+            margin-bottom: 3px;
+            position: relative;
+            padding-left: 15px;
+        }
+        .topic-tree li::before {
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+        }
+        .topic-tree li.leaf-node::before {
+            content: '□';
+        }
+        .topic-tree li.branch-node > details > summary {
+            cursor: pointer;
+            display: inline-block;
+            list-style: none;
+            margin-left: -15px;
+            padding-left: 15px;
+            position: relative;
+        }
+        .topic-tree li.branch-node > details > summary::-webkit-details-marker {
+             display: none;
+        }
+        .topic-tree li.branch-node > details > summary::before {
+            content: '▼';
+            transform: rotate(-90deg);
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node > details[open] > summary::before {
+            content: '▼';
+            transform: rotate(0deg);
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node::before {
+             content: '';
+        }
+    </style>
+    <ul>
+
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 900;"><b>Topic Tree</b></summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 800;">Topic A</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 500;">Subtopic A1</summary>
+                <ul>
+                    <li class="leaf-node" style="font-weight: 200;">Subtopic C1</li>
+<li class="leaf-node" style="font-weight: 200;">Subtopic C2</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 500;">Subtopic A2</summary>
+                <ul>
+                    <li class="leaf-node" style="font-weight: 200;">Subtopic C3</li>
+<li class="leaf-node" style="font-weight: 200;">Subtopic C4</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 800;">Topic B</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 500;">Subtopic B1</summary>
+                <ul>
+                    <li class="leaf-node" style="font-weight: 200;">Subtopic C5</li>
+<li class="leaf-node" style="font-weight: 200;">Subtopic C6</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="font-weight: 500;">Subtopic B2</summary>
+                <ul>
+                    <li class="leaf-node" style="font-weight: 200;">Subtopic C7</li>
+<li class="leaf-node" style="font-weight: 200;">Subtopic C8</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        </ul></div>"""
+
+    assert result == expected_result
+
+def test_topic_tree_html_with_colors():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    result = topic_tree_html(tree_dict, topics, variable_color=True)
+    expected_result = """<div class="topic-tree">
+    <style>
+        .topic-tree ul {
+            list-style-type: none;
+            padding-left: 25px;
+            margin-top: 5px;
+        }
+        .topic-tree li {
+            list-style-type: none;
+            margin-bottom: 3px;
+            position: relative;
+            padding-left: 15px;
+        }
+        .topic-tree li::before {
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+        }
+        .topic-tree li.leaf-node::before {
+            content: '□';
+        }
+        .topic-tree li.branch-node > details > summary {
+            cursor: pointer;
+            display: inline-block;
+            list-style: none;
+            margin-left: -15px;
+            padding-left: 15px;
+            position: relative;
+        }
+        .topic-tree li.branch-node > details > summary::-webkit-details-marker {
+             display: none;
+        }
+        .topic-tree li.branch-node > details > summary::before {
+            content: '▼';
+            transform: rotate(-90deg);
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node > details[open] > summary::before {
+            content: '▼';
+            transform: rotate(0deg);
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node::before {
+             content: '';
+        }
+    </style>
+    <ul>
+
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000; font-weight: 900;;"><b>Topic Tree</b></summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000; font-weight: 800;;">Topic A</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d; font-weight: 500;;">Subtopic A1</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C1</li>
+<li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C2</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d; font-weight: 500;;">Subtopic A2</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C3</li>
+<li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C4</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000; font-weight: 800;;">Topic B</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d; font-weight: 500;;">Subtopic B1</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C5</li>
+<li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C6</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d; font-weight: 500;;">Subtopic B2</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C7</li>
+<li class="leaf-node" style="color: #c8c8c8; font-weight: 200;;">Subtopic C8</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        </ul></div>"""
+    assert result == expected_result
+
+def test_topic_tree_html_with_colors_no_weight():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    result = topic_tree_html(tree_dict, topics, variable_color=True, variable_weight=False)
+    print(result)
+    expected_result = """<div class="topic-tree">
+    <style>
+        .topic-tree ul {
+            list-style-type: none;
+            padding-left: 25px;
+            margin-top: 5px;
+        }
+        .topic-tree li {
+            list-style-type: none;
+            margin-bottom: 3px;
+            position: relative;
+            padding-left: 15px;
+        }
+        .topic-tree li::before {
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+        }
+        .topic-tree li.leaf-node::before {
+            content: '□';
+        }
+        .topic-tree li.branch-node > details > summary {
+            cursor: pointer;
+            display: inline-block;
+            list-style: none;
+            margin-left: -15px;
+            padding-left: 15px;
+            position: relative;
+        }
+        .topic-tree li.branch-node > details > summary::-webkit-details-marker {
+             display: none;
+        }
+        .topic-tree li.branch-node > details > summary::before {
+            content: '▼';
+            transform: rotate(-90deg);
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node > details[open] > summary::before {
+            content: '▼';
+            transform: rotate(0deg);
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node::before {
+             content: '';
+        }
+    </style>
+    <ul>
+
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000;"><b>Topic Tree</b></summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000;">Topic A</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d;">Subtopic A1</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8;">Subtopic C1</li>
+<li class="leaf-node" style="color: #c8c8c8;">Subtopic C2</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d;">Subtopic A2</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8;">Subtopic C3</li>
+<li class="leaf-node" style="color: #c8c8c8;">Subtopic C4</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #000000;">Topic B</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d;">Subtopic B1</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8;">Subtopic C5</li>
+<li class="leaf-node" style="color: #c8c8c8;">Subtopic C6</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="color: #8d8d8d;">Subtopic B2</summary>
+                <ul>
+                    <li class="leaf-node" style="color: #c8c8c8;">Subtopic C7</li>
+<li class="leaf-node" style="color: #c8c8c8;">Subtopic C8</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        </ul></div>"""
+    assert result == expected_result
+
+
+def test_topic_tree_html_no_color_no_weight():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    result = topic_tree_html(tree_dict, topics, variable_color=False, variable_weight=False)
+    expected_result = """<div class="topic-tree">
+    <style>
+        .topic-tree ul {
+            list-style-type: none;
+            padding-left: 25px;
+            margin-top: 5px;
+        }
+        .topic-tree li {
+            list-style-type: none;
+            margin-bottom: 3px;
+            position: relative;
+            padding-left: 15px;
+        }
+        .topic-tree li::before {
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+        }
+        .topic-tree li.leaf-node::before {
+            content: '□';
+        }
+        .topic-tree li.branch-node > details > summary {
+            cursor: pointer;
+            display: inline-block;
+            list-style: none;
+            margin-left: -15px;
+            padding-left: 15px;
+            position: relative;
+        }
+        .topic-tree li.branch-node > details > summary::-webkit-details-marker {
+             display: none;
+        }
+        .topic-tree li.branch-node > details > summary::before {
+            content: '▼';
+            transform: rotate(-90deg);
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node > details[open] > summary::before {
+            content: '▼';
+            transform: rotate(0deg);
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node::before {
+             content: '';
+        }
+    </style>
+    <ul>
+
+        <li class="branch-node">
+            <details>
+                <summary style=""><b>Topic Tree</b></summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="">Topic A</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="">Subtopic A1</summary>
+                <ul>
+                    <li class="leaf-node" style="">Subtopic C1</li>
+<li class="leaf-node" style="">Subtopic C2</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="">Subtopic A2</summary>
+                <ul>
+                    <li class="leaf-node" style="">Subtopic C3</li>
+<li class="leaf-node" style="">Subtopic C4</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="">Topic B</summary>
+                <ul>
+                    
+        <li class="branch-node">
+            <details>
+                <summary style="">Subtopic B1</summary>
+                <ul>
+                    <li class="leaf-node" style="">Subtopic C5</li>
+<li class="leaf-node" style="">Subtopic C6</li>
+
+                </ul>
+            </details>
+        </li>
+        
+        <li class="branch-node">
+            <details>
+                <summary style="">Subtopic B2</summary>
+                <ul>
+                    <li class="leaf-node" style="">Subtopic C7</li>
+<li class="leaf-node" style="">Subtopic C8</li>
+
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        
+                </ul>
+            </details>
+        </li>
+        </ul></div>"""
+    assert result == expected_result
+
+def test_topic_tree_class():
+    tree_dict = {
+        (3, 0): [(2, 0), (2,1)],
+        (2, 0): [(1, 0), (1, 1)],
+        (2, 1): [(1, 2), (1, 3)],
+        (1, 0): [(0, 0), (0, 1)],
+        (1, 1): [(0, 2), (0, 3)],
+        (1, 2): [(0, 4), (0, 5)],
+        (1, 3): [(0, 6), (0, 7)],
+    }
+
+    topics = [
+        ["Subtopic C1", "Subtopic C2", "Subtopic C3", "Subtopic C4", "Subtopic C5", "Subtopic C6", "Subtopic C7", "Subtopic C8"],
+        ["Subtopic A1", "Subtopic A2", "Subtopic B1", "Subtopic B2"],
+        ["Topic A", "Topic B"],
+    ]
+
+    tree_instance = TopicTree(tree_dict, topics)
+    assert tree_instance.tree == tree_dict
+    assert tree_instance.topics == topics
+
+    expected_string = (
+        "Topic tree:\n"
+        "   - Topic A\n"
+        "     - Subtopic A1\n"
+        "       - Subtopic C1\n"
+        "       - Subtopic C2\n"
+        "     - Subtopic A2\n"
+        "       - Subtopic C3\n"
+        "       - Subtopic C4\n"
+        "   - Topic B\n"
+        "     - Subtopic B1\n"
+        "       - Subtopic C5\n"
+        "       - Subtopic C6\n"
+        "     - Subtopic B2\n"
+        "       - Subtopic C7\n"
+        "       - Subtopic C8\n"
+    )
+    assert str(tree_instance) == expected_string
+    assert tree_instance._repr_html_() == topic_tree_html(tree_dict, topics)
+
+def test_unfitted_toponymy_fails():
+    with pytest.raises(NotFittedError, match="This Toponymy instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator."):
+        MODEL.topic_tree_

--- a/toponymy/topic_tree.py
+++ b/toponymy/topic_tree.py
@@ -104,7 +104,7 @@ def topic_tree_html_recursion(
     elif variable_weight:
         combined_style = f"{weight_style}"
     elif variable_color:
-        combined_style = f"{weight_style}"
+        combined_style = f"{color_style}"
     else:
         combined_style = ""
 

--- a/toponymy/topic_tree.py
+++ b/toponymy/topic_tree.py
@@ -247,6 +247,26 @@ def topic_tree_html(
 
 
 class TopicTree:
+    """
+    A class to represent a topic tree. Provides string representations and
+    an HTML representation in notebooks.
+
+    Parameters
+    ----------
+    tree : ClusterTree
+        The topic tree represented as a dictionary.
+
+    topics : List[List[str]]
+        The list of topics to be included in the tree.
+    
+    Attributes
+    ----------
+    tree : ClusterTree
+        The topic tree represented as a dictionary.
+        
+    topics : List[List[str]]
+        The list of topics to be included in the tree.
+    """
     def __init__(self, tree: ClusterTree, topics: List[List[str]]):
         self.tree = tree
         self.topics = topics

--- a/toponymy/topic_tree.py
+++ b/toponymy/topic_tree.py
@@ -1,0 +1,272 @@
+import numpy as np
+import html
+from typing import Dict, List, Tuple, NewType
+from typing_extensions import Literal
+
+ClusterTree = NewType("ClusterTree", Dict[Tuple[int, int], List[Tuple[int, int]]])
+
+def topic_tree_string_recursion(
+    tree: ClusterTree,
+    root_node: Tuple[int, int],
+    topics: List[List[str]],
+    indent_level: int = 0,
+) -> str:
+    """
+    Recursively traverses the topic tree and constructs a string representation of the topics.
+
+    Parameters
+    ----------
+    tree : ClusterTree
+        The topic tree represented as a dictionary.
+    root_node : Tuple[int, int]
+        The current node in the tree.
+    topics : List[List[str]]
+        The list of topics to be included in the string representation.
+
+    Returns
+    -------
+    str
+        A string representation of the topics in the tree.
+    """
+    if root_node[0] < len(topics):
+        if root_node[1] < len(topics[root_node[0]]):
+            result = f"{' ' * indent_level} - {topics[root_node[0]][root_node[1]]}\n"
+        else:
+            result = f"{' ' * indent_level} - Unnamed topic from layer {root_node[0]} cluster {root_node[1]}\n"
+    else:
+        result = "Topic tree:\n"
+
+    for child_node in tree.get(root_node, []):
+        result += topic_tree_string_recursion(
+            tree, child_node, topics, indent_level + 2
+        )
+
+    return result
+
+
+def topic_tree_html_recursion(
+    tree_dict: ClusterTree,
+    root_node: Tuple[int, int],
+    topic_names: List[List[str]],
+    max_layer: int,
+    variable_color: bool = False,
+    variable_weight: bool = True,
+) -> str:
+    """
+    Recursively traverses the topic tree and constructs an HTML representation of the topics.
+
+    Parameters
+    ----------
+    tree_dict : ClusterTree
+        The topic tree represented as a dictionary.
+    root_node : Tuple[int, int]
+        The current node in the tree.
+    topic_names : List[List[str]]
+        The list of topics to be included in the HTML representation.
+    max_layer : int
+        The maximum layer of the tree.
+    variable_color : bool
+        If True, the color of the topic name will vary based on its layer.
+    variable_weight : bool
+        If True, the font weight of the topic name will vary based on its layer.
+
+    Returns
+    -------
+    str
+        An HTML representation of the topics in the tree.
+    """
+    layer, index = root_node
+    if layer < len(topic_names):
+        topic_name = html.escape(topic_names[layer][index])
+    else:
+        topic_name = "<b>Topic Tree</b>"
+
+    if max_layer > 0:
+        if layer == max_layer:
+            gray_val = 0
+            weight_val = 900
+        else:
+            gray_val = np.sqrt(1.0 - (layer / (max_layer - 1))) * 200
+            weight_val = 200 + (layer / (max_layer - 1)) * 600
+            weight_val = round(weight_val / 100) * 100
+    elif layer == 0:
+        gray_val = 0
+        weight_val = 800
+
+    gray_val = int(max(0, min(255, gray_val)))
+
+    # Format as hex code (e.g., #5a5a5a)
+    hex_code = f"{gray_val:02x}"
+    color_style = f"color: #{hex_code}{hex_code}{hex_code};"
+    weight_style = f"font-weight: {weight_val};"
+    if variable_weight and variable_color:
+        combined_style = f"{color_style} {weight_style};"
+    elif variable_weight:
+        combined_style = f"{weight_style}"
+    elif variable_color:
+        combined_style = f"{weight_style}"
+    else:
+        combined_style = ""
+
+    children = tree_dict.get(root_node, [])  # Get children, default to empty list
+
+    # Leaf Node
+    if not children:
+        return f'<li class="leaf-node" style="{combined_style}">{topic_name}</li>\n'
+
+    # Node with Children
+    else:
+        child_html_items = ""
+        for child_id in children:
+            child_html_items += topic_tree_html_recursion(
+                tree_dict,
+                child_id,
+                topic_names,
+                max_layer=max_layer,
+                variable_color=variable_color,
+                variable_weight=variable_weight,
+            )
+
+        html_content = f"""
+        <li class="branch-node">
+            <details>
+                <summary style="{combined_style}">{topic_name}</summary>
+                <ul>
+                    {child_html_items}
+                </ul>
+            </details>
+        </li>
+        """
+        return html_content
+
+
+def topic_tree_html(
+    tree_dict: ClusterTree,
+    topic_names: List[List[str]],
+    variable_color: bool = False,
+    variable_weight: bool = True,
+) -> str:
+    """
+    Converts a topic tree into an HTML representation.
+    
+    Parameters
+    ----------
+    
+    tree_dict : ClusterTree
+        The topic tree represented as a dictionary.
+    topic_names : List[List[str]]
+        The list of topics to be included in the HTML representation.
+    variable_color : bool
+        If True, the color of the topic name will vary based on its layer.
+    variable_weight : bool
+        If True, the font weight of the topic name will vary based on its layer.
+        
+    Returns
+    -------
+    str
+        An HTML representation of the topics in the tree.
+    """
+    root_node = max(
+        tree_dict.keys(),
+    )
+    # Start the main HTML list
+    root_html = "<ul>\n"
+    root_html += topic_tree_html_recursion(
+        tree_dict,
+        root_node,
+        topic_names,
+        max_layer=root_node[0],
+        variable_color=variable_color,
+        variable_weight=variable_weight,
+    )
+    root_html += "</ul>"
+
+    # Add CSS styles for the topic tree
+    style = """
+    <style>
+        .topic-tree ul {
+            list-style-type: none;
+            padding-left: 25px;
+            margin-top: 5px;
+        }
+        .topic-tree li {
+            list-style-type: none;
+            margin-bottom: 3px;
+            position: relative;
+            padding-left: 15px;
+        }
+        .topic-tree li::before {
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+        }
+        .topic-tree li.leaf-node::before {
+            content: '□';
+        }
+        .topic-tree li.branch-node > details > summary {
+            cursor: pointer;
+            display: inline-block;
+            list-style: none;
+            margin-left: -15px;
+            padding-left: 15px;
+            position: relative;
+        }
+        .topic-tree li.branch-node > details > summary::-webkit-details-marker {
+             display: none;
+        }
+        .topic-tree li.branch-node > details > summary::before {
+            content: '▼';
+            transform: rotate(-90deg);
+            position: absolute;
+            left: 0;
+            top: 0.15em;
+            font-size: 0.9em;
+            width: 1em;
+            text-align: center;
+            color: #555;
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node > details[open] > summary::before {
+            content: '▼';
+            transform: rotate(0deg);
+            transition: transform 0.25s ease-in-out;
+        }
+        .topic-tree li.branch-node::before {
+             content: '';
+        }
+    </style>
+    """
+
+    result = f'<div class="topic-tree">{style}{root_html}</div>'
+
+    return result
+
+
+class TopicTree:
+    def __init__(self, tree: ClusterTree, topics: List[List[str]]):
+        self.tree = tree
+        self.topics = topics
+
+    def __str__(self) -> str:
+        root_node = max(
+            self.tree.keys(),
+        )
+        result = topic_tree_string_recursion(
+            self.tree,
+            root_node,
+            self.topics,
+            indent_level=0,
+        )
+        return result
+    
+    def _repr_html_(self) -> str:
+        return topic_tree_html(
+            self.tree,
+            self.topics,
+            variable_color=False,
+            variable_weight=True,
+        )

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -279,9 +279,19 @@ class Toponymy:
         TopicTree
             A representation of the topic tree (either html or string).
         """
-        check_is_fitted(self, ["cluster_tree_", "topic_names_"])
+        check_is_fitted(self, ["cluster_tree_", "topic_names_", "topic_name_vectors_"])
+        def cluster_size(cluster_label_array):
+            if cluster_label_array.min() < 0:
+                return np.bincount(cluster_label_array - cluster_label_array.min())[-cluster_label_array.min():].tolist()
+            else:
+                return np.bincount(cluster_label_array).tolist()
+        topic_sizes = [
+            cluster_size(layer.cluster_labels) for layer in self.cluster_layers_
+        ]
         return TopicTree(
             self.cluster_tree_,
             self.topic_names_,
+            topic_sizes,
+            self.embedding_vectors_.shape[0],
         )
 

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -279,7 +279,7 @@ class Toponymy:
         TopicTree
             A representation of the topic tree (either html or string).
         """
-        check_is_fitted(self, ["cluster_tree_", "topic_names"])
+        check_is_fitted(self, ["cluster_tree_", "topic_names_"])
         return TopicTree(
             self.cluster_tree_,
             self.topic_names_,

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -4,6 +4,7 @@ from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from toponymy.topic_tree import TopicTree
 
 from sentence_transformers import SentenceTransformer
+from sklearn.utils.validation import check_is_fitted
 import numpy as np
 
 from tqdm.auto import tqdm
@@ -278,6 +279,7 @@ class Toponymy:
         TopicTree
             A representation of the topic tree (either html or string).
         """
+        check_is_fitted(self, ["cluster_tree_", "topic_names"])
         return TopicTree(
             self.cluster_tree_,
             self.topic_names_,

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -1,6 +1,7 @@
 from toponymy.clustering import ToponymyClusterer, Clusterer
 from toponymy.keyphrases import KeyphraseBuilder
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
+from toponymy.topic_tree import TopicTree
 
 from sentence_transformers import SentenceTransformer
 import numpy as np
@@ -266,3 +267,19 @@ class Toponymy:
         """
         self.fit(objects, object_vectors, clusterable_vectors)
         return self.topic_name_vectors_
+    
+    @property
+    def topic_tree_(self) -> TopicTree:
+        """
+        Returns the topic tree.
+        
+        Returns:
+        --------
+        TopicTree
+            A representation of the topic tree (either html or string).
+        """
+        return TopicTree(
+            self.cluster_tree_,
+            self.topic_names_,
+        )
+


### PR DESCRIPTION
Add support for printable/viewable topic trees upon completion of fitting a model. This works well in Jupyter with an HTML output via ``_repr_html_``. Should help to resolve issue #37 .