### PR TITLE
Support tokenizers for keyphrase extraction

### DIFF
--- a/toponymy/tests/test_keyphrases.py
+++ b/toponymy/tests/test_keyphrases.py
@@ -41,7 +41,7 @@ TOPIC_OBJECTS = json.load(open(Path(__file__).parent / "topic_objects.json", "r"
 ALL_TOPIC_OBJECTS = sum([x["paragraphs"] for x in TOPIC_OBJECTS], [])
 CLUSTER_LAYER = np.concatenate([np.arange(10).repeat(10), np.full(10, -1)])
 MATRIX, KEYPHRASES = build_object_x_keyphrase_matrix(
-    ALL_TOPIC_OBJECTS, ngrammer=BASE_NGRAMMER,
+    ALL_TOPIC_OBJECTS, token_pattern=r"(?u)\b\w\w+\b", ngram_range=(1, 1)
 )
 TOPIC_VECTORS = EMBEDDER.encode(ALL_TOPIC_OBJECTS)
 KEYPHRASE_VECTORS = EMBEDDER.encode(KEYPHRASES)

--- a/toponymy/tests/test_keyphrases.py
+++ b/toponymy/tests/test_keyphrases.py
@@ -1,4 +1,5 @@
 from toponymy.keyphrases import (
+    create_tokenizers_ngrammer,
     build_object_x_keyphrase_matrix,
     build_keyphrase_vocabulary,
     build_keyphrase_count_matrix,
@@ -60,6 +61,18 @@ def test_vocabulary_building(max_features, ngram_range):
     assert (" ".join(["quick", "brown", "fox", "jumps"][:ngram_range])) in vocabulary
     assert (" ".join(["sleeping", "dogs", "lie"][:ngram_range])) in vocabulary
 
+
+@pytest.mark.parametrize("max_features", [900, 450])
+@pytest.mark.parametrize("ngram_range", [4, 3, 2, 1])
+def test_tokenizer_vocabulary_building(max_features, ngram_range):
+    ngrammer = create_tokenizers_ngrammer(EMBEDDER.tokenizer, (1, ngram_range))
+    vocabulary = build_keyphrase_vocabulary(
+        TEST_OBJECTS, n_jobs=4, max_features=max_features, ngrammer=ngrammer
+    )
+    assert len(vocabulary) <= max_features
+    assert "the" not in vocabulary
+    assert (" ".join(["quick", "brown", "fox", "jumps"][:ngram_range])) in vocabulary
+    assert (" ".join(["sleeping", "dogs", "lie"][:ngram_range])) in vocabulary
 
 @pytest.mark.parametrize("ngram_range", [4, 3, 2, 1])
 def test_count_matrix_building(ngram_range):

--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -16,8 +16,8 @@ import umap
 
 import pytest
 
-# LLM = HuggingFace("Qwen/Qwen2.5-0.5B-Instruct")
-LLM = HuggingFace("Qwen/Qwen3.0-0.6B")
+LLM = HuggingFace("Qwen/Qwen2.5-0.5B-Instruct")
+# LLM = HuggingFace("Qwen/Qwen3.0-0.6B")
 EMBEDDER = SentenceTransformer("all-MiniLM-L6-v2")
 SUBTOPIC_OBJECTS = json.load(open(Path(__file__).parent / "subtopic_objects.json", "r"))
 ALL_SENTENCES = sum(

--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -16,7 +16,8 @@ import umap
 
 import pytest
 
-LLM = HuggingFace("Qwen/Qwen2.5-0.5B-Instruct")
+# LLM = HuggingFace("Qwen/Qwen2.5-0.5B-Instruct")
+LLM = HuggingFace("Qwen/Qwen3.0-0.6B")
 EMBEDDER = SentenceTransformer("all-MiniLM-L6-v2")
 SUBTOPIC_OBJECTS = json.load(open(Path(__file__).parent / "subtopic_objects.json", "r"))
 ALL_SENTENCES = sum(


### PR DESCRIPTION
This will allow users to provide a tokenizer to be used for splitting text in keyphrase extraction. This has some drawbacks and sub-word parts can become keywords, but it provides a great deal more flexibility, and allows for keyphrases made up of, for example, punctuation used as delimiters, various asian languages, etc.