### PR TITLE
On demand keyphrase vectors

### DIFF
--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -91,6 +91,7 @@ class ClusterLayer(ABC):
         keyphrase_list: List[str],
         object_x_keyphrase_matrix: scipy.sparse.spmatrix,
         keyphrase_vectors: np.ndarray,
+        embedding_model: SentenceTransformer,
     ) -> List[List[str]]:
         pass
 
@@ -377,12 +378,14 @@ class ClusterLayerText(ClusterLayer):
         keyphrase_list: List[str],
         object_x_keyphrase_matrix: scipy.sparse.spmatrix,
         keyphrase_vectors: np.ndarray,
+        embedding_model: SentenceTransformer,
     ) -> List[List[str]]:
         self.keyphrases = information_weighted_keyphrases(
             self.cluster_labels,
             object_x_keyphrase_matrix,
             keyphrase_list,
             keyphrase_vectors,
+            embedding_model,
             diversify_alpha=self.keyphrase_diversify_alpha,
             n_keyphrases=self.n_keyphrases,
             show_progress_bar=self.show_progress_bar,

--- a/toponymy/keyphrases.py
+++ b/toponymy/keyphrases.py
@@ -550,11 +550,12 @@ def information_weighted_keyphrases(
         ]
         # Update keyphrase mapping with present keyphrases it is missing
         missing_keyphrases = [keyphrase for keyphrase in keyphrases_present if keyphrase not in keyphrase_vector_mapping]
-        missing_keyphrase_vectors = embedding_model.encode(
-            missing_keyphrases, show_progress_bar=False
-        )
-        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
-            keyphrase_vector_mapping[keyphrase] = vector
+        if len(missing_keyphrases) > 0:
+            missing_keyphrase_vectors = embedding_model.encode(
+                missing_keyphrases, show_progress_bar=False
+            )
+            for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+                keyphrase_vector_mapping[keyphrase] = vector
 
         # Compute the centroid of the keyphrases present in the cluster
         centroid_vector = np.average(
@@ -662,11 +663,12 @@ def central_keyphrases(
         ]
         # Update keyphrase mapping with present keyphrases it is missing
         missing_keyphrases = [keyphrase for keyphrase in base_candidates if keyphrase not in keyphrase_vector_mapping]
-        missing_keyphrase_vectors = embedding_model.encode(
-            missing_keyphrases, show_progress_bar=False
-        )
-        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
-            keyphrase_vector_mapping[keyphrase] = vector
+        if len(missing_keyphrases) > 0:
+            missing_keyphrase_vectors = embedding_model.encode(
+                missing_keyphrases, show_progress_bar=False
+            )
+            for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+                keyphrase_vector_mapping[keyphrase] = vector
 
         base_vectors = np.asarray(
             [keyphrase_vector_mapping[phrase] for phrase in base_candidates]
@@ -808,11 +810,12 @@ def bm25_keyphrases(
         ]
                 # Update keyphrase mapping with present keyphrases it is missing
         missing_keyphrases = [keyphrase for keyphrase in keyphrases_present if keyphrase not in keyphrase_vector_mapping]
-        missing_keyphrase_vectors = embedding_model.encode(
-            missing_keyphrases, show_progress_bar=False
-        )
-        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
-            keyphrase_vector_mapping[keyphrase] = vector
+        if len(missing_keyphrases) > 0:
+            missing_keyphrase_vectors = embedding_model.encode(
+                missing_keyphrases, show_progress_bar=False
+            )
+            for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+                keyphrase_vector_mapping[keyphrase] = vector
 
         # Compute the centroid of the keyphrases present in the cluster
         centroid_vector = np.average(

--- a/toponymy/keyphrases.py
+++ b/toponymy/keyphrases.py
@@ -9,6 +9,8 @@ from toponymy.utility_functions import diversify_max_alpha as diversify
 from vectorizers.transformers import InformationWeightTransformer
 from sklearn.metrics import pairwise_distances
 
+from sentence_transformers import SentenceTransformer
+
 import scipy.sparse
 import numba
 
@@ -472,6 +474,7 @@ def information_weighted_keyphrases(
     object_x_keyphrase_matrix: scipy.sparse.spmatrix,
     keyphrase_list: List[str],
     keyphrase_vectors: np.ndarray,
+    embedding_model: SentenceTransformer,
     n_keyphrases: int = 16,
     prior_strength: float = 0.1,
     weight_power: float = 2.0,
@@ -490,6 +493,8 @@ def information_weighted_keyphrases(
         A list of keyphrases in the same order as columns in object_x_keyphrase_matrix.
     keyphrase_vectors : np.ndarray
         An ndarray of keyphrase vectors in the same order as columns in object_x_keyphrase_matrix.
+    embedding_model : SentenceTransformer
+        A SentenceTransformer model for embedding keyphrases.
     n_keyphrases : int, optional
         The number of keyphrases to generate for each cluster, by default 16.
     prior_strength : float, optional
@@ -508,7 +513,7 @@ def information_weighted_keyphrases(
     """
     keyphrase_vector_mapping = {
         keyphrase: vector
-        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors)
+        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors) if not np.all(vector == 0.0)
     }
     count_matrix, class_labels, column_map = subset_matrix_and_class_labels(
         cluster_label_vector, object_x_keyphrase_matrix
@@ -543,6 +548,15 @@ def information_weighted_keyphrases(
         keyphrases_present = [
             keyphrase_list[column_map[j]] for j in keyphrases_present_indices
         ]
+        # Update keyphrase mapping with present keyphrases it is missing
+        missing_keyphrases = [keyphrase for keyphrase in keyphrases_present if keyphrase not in keyphrase_vector_mapping]
+        missing_keyphrase_vectors = embedding_model.encode(
+            missing_keyphrases, show_progress_bar=False
+        )
+        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+            keyphrase_vector_mapping[keyphrase] = vector
+
+        # Compute the centroid of the keyphrases present in the cluster
         centroid_vector = np.average(
             [keyphrase_vector_mapping[keyphrase] for keyphrase in keyphrases_present],
             weights=keyphrase_weights,
@@ -553,7 +567,7 @@ def information_weighted_keyphrases(
 
         # Map the indices back to the original vocabulary
         chosen_keyphrases = [
-            keyphrase_list[column_map[j]] for j in reversed(chosen_indices)
+            keyphrase_list[column_map[j]] for j in reversed(chosen_indices) if j in keyphrases_present_indices
         ]
 
         # Extract the longest keyphrases, then diversify the selection
@@ -571,6 +585,11 @@ def information_weighted_keyphrases(
 
         result.append(chosen_keyphrases)
 
+    # Update keyphrase vectors with vectors from the mapping
+    for i, keyphrase in enumerate(keyphrase_list):
+        if keyphrase in keyphrase_vector_mapping:
+            keyphrase_vectors[i] = keyphrase_vector_mapping[keyphrase]
+
     return result
 
 
@@ -579,6 +598,7 @@ def central_keyphrases(
     object_x_keyphrase_matrix: scipy.sparse.spmatrix,
     keyphrase_list: List[str],
     keyphrase_vectors: np.ndarray,
+    embedding_model: SentenceTransformer,
     n_keyphrases: int = 16,
     diversify_alpha: float = 1.0,
     show_progress_bar: bool = False,
@@ -596,6 +616,8 @@ def central_keyphrases(
         A list of keyphrases in the same order as columns in object_x_keyphrase_matrix.
     keyphrase_vectors : np.ndarray
         An ndarray of keyphrase vectors in the same order as columns in object_x_keyphrase_matrix.
+    embedding_model : SentenceTransformer
+        A SentenceTransformer model for embedding keyphrases.
     n_keyphrases : int, optional
         The number of keyphrases to generate for each cluster, by default 16.
     diversify_alpha : float, optional
@@ -610,7 +632,7 @@ def central_keyphrases(
     """
     keyphrase_vector_mapping = {
         keyphrase: vector
-        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors)
+        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors) if not np.all(vector == 0.0)
     }
 
     count_matrix, class_labels, column_map = subset_matrix_and_class_labels(
@@ -638,6 +660,14 @@ def central_keyphrases(
         base_candidates = [
             keyphrase_list[column_map[j]] for j in base_candidate_indices
         ]
+        # Update keyphrase mapping with present keyphrases it is missing
+        missing_keyphrases = [keyphrase for keyphrase in base_candidates if keyphrase not in keyphrase_vector_mapping]
+        missing_keyphrase_vectors = embedding_model.encode(
+            missing_keyphrases, show_progress_bar=False
+        )
+        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+            keyphrase_vector_mapping[keyphrase] = vector
+
         base_vectors = np.asarray(
             [keyphrase_vector_mapping[phrase] for phrase in base_candidates]
         )
@@ -666,6 +696,12 @@ def central_keyphrases(
 
         result.append(chosen_keyphrases)
 
+
+    # Update keyphrase vectors with vectors from the mapping
+    for i, keyphrase in enumerate(keyphrase_list):
+        if keyphrase in keyphrase_vector_mapping:
+            keyphrase_vectors[i] = keyphrase_vector_mapping[keyphrase]
+            
     return result
 
 
@@ -674,6 +710,7 @@ def bm25_keyphrases(
     object_x_keyphrase_matrix: scipy.sparse.spmatrix,
     keyphrase_list: List[str],
     keyphrase_vectors: np.ndarray,
+    embedding_model: SentenceTransformer,
     n_keyphrases: int = 16,
     k1: float = 1.5,
     b: float = 0.75,
@@ -692,6 +729,8 @@ def bm25_keyphrases(
         A list of keyphrases in the same order as columns in object_x_keyphrase_matrix.
     keyphrase_vectors : np.ndarray
         An ndarray of keyphrase vectors in the same order as columns in object_x_keyphrase_matrix.
+    embedding_model : SentenceTransformer
+        A SentenceTransformer model for embedding keyphrases.
     n_keyphrases : int, optional
         The number of keyphrases to generate for each cluster, by default 16.
     k1 : float, optional
@@ -708,7 +747,7 @@ def bm25_keyphrases(
     """
     keyphrase_vector_mapping = {
         keyphrase: vector
-        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors)
+        for keyphrase, vector in zip(keyphrase_list, keyphrase_vectors) if not np.all(vector == 0.0)
     }
 
     count_matrix, class_labels, column_map = subset_matrix_and_class_labels(
@@ -767,6 +806,15 @@ def bm25_keyphrases(
         keyphrases_present = [
             keyphrase_list[column_map[j]] for j in keyphrases_present_indices
         ]
+                # Update keyphrase mapping with present keyphrases it is missing
+        missing_keyphrases = [keyphrase for keyphrase in keyphrases_present if keyphrase not in keyphrase_vector_mapping]
+        missing_keyphrase_vectors = embedding_model.encode(
+            missing_keyphrases, show_progress_bar=False
+        )
+        for keyphrase, vector in zip(missing_keyphrases, missing_keyphrase_vectors):
+            keyphrase_vector_mapping[keyphrase] = vector
+
+        # Compute the centroid of the keyphrases present in the cluster
         centroid_vector = np.average(
             [keyphrase_vector_mapping[keyphrase] for keyphrase in keyphrases_present],
             weights=keyphrase_weights,
@@ -777,7 +825,7 @@ def bm25_keyphrases(
 
         # Map the indices back to the original vocabulary
         chosen_keyphrases = [
-            keyphrase_list[column_map[j]] for j in reversed(chosen_indices)
+            keyphrase_list[column_map[j]] for j in reversed(chosen_indices) if j in keyphrases_present_indices
         ]
 
         # Extract the longest keyphrases, then diversify the selection
@@ -794,5 +842,11 @@ def bm25_keyphrases(
         chosen_keyphrases = [chosen_keyphrases[j] for j in chosen_indices]
 
         result.append(chosen_keyphrases)
+
+
+    # Update keyphrase vectors with vectors from the mapping
+    for i, keyphrase in enumerate(keyphrase_list):
+        if keyphrase in keyphrase_vector_mapping:
+            keyphrase_vectors[i] = keyphrase_vector_mapping[keyphrase]
 
     return result

--- a/toponymy/prompt_construction.py
+++ b/toponymy/prompt_construction.py
@@ -175,6 +175,8 @@ def distinguish_topic_names_prompt(
         larger_topic = (
             ", ".join(unique_topic_names[:-1]) + " and " + unique_topic_names[-1]
         )
+    if len(larger_topic) == 0: 
+        larger_topic = f"topics found in {corpus_description}"
 
     keyphrases_per_topic = [keyphrases[i][:max_num_keyphrases] for i in topic_indices]
     exemplar_texts_per_topic = [

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -70,7 +70,7 @@ where SCORE is a value in the range 0 to 1.
 You are an expert in {{larger_topic}}, and have been asked to provide a more specific names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
-Below are the auto-generated topic names, along with some keywords associated to each topic, and a sampling of {{self.document_type}} from the topic area.
+Below are the auto-generated topic names, along with some keywords associated to each topic, and a sampling of {{document_type}} from the topic area.
 
 {% for topic in topics %}
 

--- a/toponymy/tests/test_cluster_layers.py
+++ b/toponymy/tests/test_cluster_layers.py
@@ -43,7 +43,7 @@ def test_abstract_cluster_layer():
         ALL_SENTENCES, OBJECT_VECTORS
     )
     keyphrases = concrete_cluster_layer.make_keyphrases(
-        ALL_SENTENCES, csr_matrix(np.array([[1, 0], [0, 1]])), OBJECT_VECTORS
+        ALL_SENTENCES, csr_matrix(np.array([[1, 0], [0, 1]])), OBJECT_VECTORS, EMBEDDER
     )
     subtopics = concrete_cluster_layer.make_subtopics(
         ALL_SUBTOPICS, SUBTOPIC_LABEL_VECTOR, SUBTOPIC_CENTROID_VECTORS
@@ -95,7 +95,7 @@ def test_make_data():
     matrix, keyphrases = keyphrase_builder.fit_transform(ALL_SENTENCES)
     keyphrase_vectors = EMBEDDER.encode(keyphrases)
     cluster_layer.make_exemplar_texts(ALL_SENTENCES, OBJECT_VECTORS)
-    cluster_layer.make_keyphrases(keyphrases, matrix, keyphrase_vectors)
+    cluster_layer.make_keyphrases(keyphrases, matrix, keyphrase_vectors, EMBEDDER)
     cluster_layer.make_subtopics(
         ALL_SUBTOPICS, SUBTOPIC_LABEL_VECTOR, SUBTOPIC_CENTROID_VECTORS
     )

--- a/toponymy/tests/test_keyphrases.py
+++ b/toponymy/tests/test_keyphrases.py
@@ -170,6 +170,7 @@ def test_central_keyphrases_result_sizes(n_keyphrases, diversify_alpha):
         MATRIX,
         KEYPHRASES,
         KEYPHRASE_VECTORS,
+        EMBEDDER,
         diversify_alpha=diversify_alpha,
         n_keyphrases=n_keyphrases,
     )
@@ -186,6 +187,7 @@ def test_central_keyphrases():
         MATRIX,
         KEYPHRASES,
         KEYPHRASE_VECTORS,
+        EMBEDDER,
         diversify_alpha=0.0,
         n_keyphrases=10,
     )
@@ -224,6 +226,7 @@ def test_bm25_keyphrases_result_sizes(n_keyphrases, diversify_alpha):
         MATRIX,
         KEYPHRASES,
         KEYPHRASE_VECTORS,
+        EMBEDDER,
         diversify_alpha=diversify_alpha,
         n_keyphrases=n_keyphrases,
     )
@@ -238,6 +241,7 @@ def test_bm25_keyphrases():
         MATRIX,
         KEYPHRASES,
         KEYPHRASE_VECTORS,
+        EMBEDDER,
         diversify_alpha=0.0,
     )
     bm25_objects = [
@@ -274,6 +278,7 @@ def test_information_weighted_keyphrases_result_sizes(n_keyphrases, diversify_al
         MATRIX,
         KEYPHRASES,
         KEYPHRASE_VECTORS,
+        EMBEDDER,
         diversify_alpha=diversify_alpha,
         n_keyphrases=n_keyphrases,
     )
@@ -286,7 +291,8 @@ def test_information_weighted_keyphrases():
         CLUSTER_LAYER,
         MATRIX,
         KEYPHRASES,
-        KEYPHRASE_VECTORS,
+        np.zeros_like(KEYPHRASE_VECTORS),
+        EMBEDDER,
         diversify_alpha=0.0,
     )
     sub_matrix, class_layer, column_map = subset_matrix_and_class_labels(CLUSTER_LAYER, MATRIX)

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -138,6 +138,7 @@ class Toponymy:
         self: object
             Returns the instance of the class.
         """
+        pre_embed_all_keyphrases = True # True if the keyphrase vectors should be pre-embedded.  This is useful for large datasets where we want to save time later.
         self.clusterable_vectors_ = clusterable_vectors
         self.embedding_vectors_ = embedding_vectors
 
@@ -194,7 +195,7 @@ class Toponymy:
                 embedding_vectors,
             )
         
-        if False:
+        if pre_embed_all_keyphrases:
             # Generate keyphrase vectors ahead of time
             self.keyphrase_vectors_ = self.embedding_model.encode(
                 self.keyphrase_list_, 
@@ -206,7 +207,7 @@ class Toponymy:
                 embedding_dimension = self.embedding_model.get_sentence_embedding_dimension()
             except AttributeError:
                 embedding_dimension = self.embedding_model.encode(["Get the embedding dimension of this string"]).shape[1]
-                
+
             self.keyphrase_vectors_ = np.zeros((len(self.keyphrase_list_), embedding_dimension))
 
         # Iterate through the layers and build the topic names

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -202,7 +202,12 @@ class Toponymy:
             )
         else:
             # Initialize keyphrase vectors to zero, and fill on demand later
-            self.keyphrase_vectors_ = np.zeros((len(self.keyphrase_list_), self.embedding_model.get_sentence_embedding_dimension()))
+            try:
+                embedding_dimension = self.embedding_model.get_sentence_embedding_dimension()
+            except AttributeError:
+                embedding_dimension = self.embedding_model.encode(["Get the embedding dimension of this string"]).shape[1]
+                
+            self.keyphrase_vectors_ = np.zeros((len(self.keyphrase_list_), embedding_dimension))
 
         # Iterate through the layers and build the topic names
         for i, layer in tqdm(

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -194,11 +194,15 @@ class Toponymy:
                 embedding_vectors,
             )
         
-        # Generate keyphrase vectors
-        self.keyphrase_vectors_ = self.embedding_model.encode(
-            self.keyphrase_list_, 
-            show_progress_bar=self.show_progress_bars,
-        )
+        if False:
+            # Generate keyphrase vectors ahead of time
+            self.keyphrase_vectors_ = self.embedding_model.encode(
+                self.keyphrase_list_, 
+                show_progress_bar=self.show_progress_bars,
+            )
+        else:
+            # Initialize keyphrase vectors to zero, and fill on demand later
+            self.keyphrase_vectors_ = np.zeros((len(self.keyphrase_list_), self.embedding_model.get_sentence_embedding_dimension()))
 
         # Iterate through the layers and build the topic names
         for i, layer in tqdm(
@@ -218,6 +222,7 @@ class Toponymy:
                 self.keyphrase_list_,
                 self.object_x_keyphrase_matrix_,
                 self.keyphrase_vectors_,
+                self.embedding_model,
             )
             
             if i > 0:


### PR DESCRIPTION
If you have a lot of keyphrases, many of which don't actually occur in actually clustered documents, we can save ourselves significant trouble by generating keyphrase vectors on the fly rather than up-front. This allows for this possibility, without necessarily explicitly enabling it.