### PR TITLE
System prompts for LLMs that Support it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ toponymy/__pycache__/*.pyc
 toponymy/tests/__pycache__/*.pyc
 toponymy/__pycache__/*.nbc
 toponymy/__pycache__/*.nbi
+.mypy_cache/*
 .coverage*

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -42,6 +42,8 @@ class ClusterLayer(ABC):
         n_keyphrases: int = 24,
         n_subtopics: int = 24,
         exemplar_delimiters: List[str] = ["    * \"", "\"\n"],
+        prompt_format: str = "combined",
+        prompt_template: Optional[str] = None,
         show_progress_bar: bool = False,
     ):
         self.cluster_labels = cluster_labels
@@ -53,6 +55,8 @@ class ClusterLayer(ABC):
         self.n_keyphrases = n_keyphrases
         self.n_subtopics = n_subtopics
         self.exemplar_delimiters = exemplar_delimiters
+        self.prompt_format = prompt_format
+        self.prompt_template = prompt_template
         self.show_progress_bar = show_progress_bar
 
         # Initialize empty lists for the cluster layer's attributes
@@ -172,6 +176,8 @@ class ClusterLayer(ABC):
                 max_num_subtopics=self.n_subtopics,
                 exemplar_start_delimiter=self.exemplar_delimiters[0],
                 exemplar_end_delimiter=self.exemplar_delimiters[1],
+                prompt_format=self.prompt_format,
+                prompt_template=self.prompt_template,
             )
             for topic_indices in tqdm(
                 self.dismbiguation_topic_indices,
@@ -254,6 +260,8 @@ class ClusterLayerText(ClusterLayer):
         n_subtopics: int = 16,
         subtopic_diversify_alpha: float = 1.0,
         exemplar_delimiters: List[str] = ["    * \"", "\"\n"],
+        prompt_format: str = "combined",
+        prompt_template: Optional[str] = None,
         show_progress_bar: bool = False,
     ):
         super().__init__(
@@ -262,6 +270,8 @@ class ClusterLayerText(ClusterLayer):
             layer_id,
             text_embedding_model,
             exemplar_delimiters=exemplar_delimiters,
+            prompt_format=prompt_format,
+            prompt_template=prompt_template,
             show_progress_bar=show_progress_bar,
         )
         self.n_keyphrases = n_keyphrases
@@ -301,6 +311,8 @@ class ClusterLayerText(ClusterLayer):
                 max_num_subtopics=self.n_subtopics,
                 exemplar_start_delimiter=self.exemplar_delimiters[0],
                 exemplar_end_delimiter=self.exemplar_delimiters[1],
+                prompt_format=self.prompt_format,
+                prompt_template=self.prompt_template,
             )
             for topic_index in tqdm(
                 range(self.centroid_vectors.shape[0]),
@@ -328,7 +340,7 @@ class ClusterLayerText(ClusterLayer):
         self.topic_names = [
             (
                 llm.generate_topic_name(prompt)
-                if not prompt.startswith("[!SKIP!]: ")
+                if isinstance(prompt, dict) or not prompt.startswith("[!SKIP!]: ")
                 else prompt.removeprefix("[!SKIP!]: ")
             )
             for prompt in tqdm(

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -6,7 +6,7 @@ import transformers
 
 from toponymy.templates import GET_TOPIC_CLUSTER_NAMES_REGEX, GET_TOPIC_NAME_REGEX
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Union, Dict
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 import re
@@ -65,12 +65,12 @@ def llm_output_to_result(llm_output: str, regex: str) -> dict:
 class LLMWrapper(ABC):
 
     @abstractmethod
-    def generate_topic_name(self, prompt: str, temperature: float) -> str:
+    def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float) -> str:
         pass
 
     @abstractmethod
     def generate_topic_cluster_names(
-        self, prompt: str, old_names: List[str], temperature: float
+        self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float
     ) -> List[str]:
         pass
 
@@ -94,7 +94,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.8) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.8) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info = self.llm(
@@ -125,7 +125,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             if isinstance(prompt, str):
                 topic_name_info_raw = self.llm(
@@ -182,7 +182,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.8) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.8) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info_raw = self.llm(
@@ -222,7 +222,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             if isinstance(prompt, str):
                 topic_name_info_raw = self.llm(
@@ -301,7 +301,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.5) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.5) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info_raw = self.llm.chat(
@@ -339,7 +339,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             if isinstance(prompt, str):
                 topic_name_info_raw = self.llm.chat(
@@ -407,7 +407,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.5) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.5) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info_raw = self.llm.messages.create(
@@ -447,7 +447,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             try:
                 if isinstance(prompt, str):
@@ -526,7 +526,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.5) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.5) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info_raw = self.llm.chat.completions.create(
@@ -571,7 +571,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             try:
                 if isinstance(prompt, str):
@@ -651,7 +651,7 @@ try:
             wait=wait_exponential(multiplier=1, min=4, max=10),
             retry_error_callback=lambda x: "",
         )
-        def generate_topic_name(self, prompt: str, temperature: float = 0.5) -> str:
+        def generate_topic_name(self, prompt: Union[str, Dict[str, str]], temperature: float = 0.5) -> str:
             try:
                 if isinstance(prompt, str):
                     topic_name_info_raw = self.llm.complete(
@@ -684,7 +684,7 @@ try:
             retry_error_callback=lambda retry_state: retry_state.args[2],
         )
         def generate_topic_cluster_names(
-            self, prompt: str, old_names: List[str], temperature: float = 0.5
+            self, prompt: Union[str, Dict[str, str]], old_names: List[str], temperature: float = 0.5
         ) -> List[str]:
             try:
                 if isinstance(prompt, str):

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -117,9 +117,6 @@ try:
                         f"Prompt must be a string or a dictionary, got {type(prompt)}"
                     )
                 
-                topic_name_info = self.llm(
-                    prompt, temperature=temperature, max_tokens=256
-                )["choices"][0]["text"]
                 topic_name_info = llm_output_to_result(topic_name_info, GET_TOPIC_NAME_REGEX)
                 topic_name = topic_name_info["topic_name"]
             except Exception as e:

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -74,6 +74,14 @@ class LLMWrapper(ABC):
     ) -> List[str]:
         pass
 
+    @property
+    def supports_system_prompts(self) -> bool:
+        """
+        Check if the LLM wrapper supports system prompts.
+        By default, it does. Override in subclasses if not supported.
+        """
+        return True
+
 
 try:
 
@@ -163,6 +171,10 @@ try:
                     return new_names
                 else:
                     raise ValueError(f"Failed to generate enough names when fixing {old_names}; got {mapping}")
+
+        @property
+        def supports_system_prompts(self) -> bool:
+            return False
 
 except ImportError:
     pass
@@ -473,6 +485,8 @@ try:
                     )
                 
                 topic_name_info_text = topic_name_info_raw.content[0].text
+                if topic_name_info_text is None:
+                    raise ValueError(f"Empty response from Anthropic")
                 topic_name_info = llm_output_to_result(
                     topic_name_info_text, GET_TOPIC_CLUSTER_NAMES_REGEX
                 )
@@ -553,7 +567,8 @@ try:
                     )
                 
                 topic_name_info_text = topic_name_info_raw.choices[0].message.content
-
+                if topic_name_info_text is None:
+                    raise ValueError(f"Empty response from OpenAI API")
                 topic_name_info = llm_output_to_result(
                     topic_name_info_text, GET_TOPIC_NAME_REGEX
                 )
@@ -599,6 +614,8 @@ try:
                     )
                 
                 topic_name_info_text = topic_name_info_raw.choices[0].message.content
+                if topic_name_info_text is None:
+                    raise ValueError(f"Empty response from OpenAI API")
                 topic_name_info = llm_output_to_result(
                     topic_name_info_text, GET_TOPIC_CLUSTER_NAMES_REGEX
                 )

--- a/toponymy/prompt_construction.py
+++ b/toponymy/prompt_construction.py
@@ -125,7 +125,7 @@ def distinguish_topic_names_prompt(
     exemplar_start_delimiter: str = "    * \"",
     exemplar_end_delimiter: str = "\"\n",
     prompt_format: str = "combined",
-    prompt_template: Optional[str] = None,
+    prompt_template: Optional[Dict[str, Any]] = None,
 ) -> Union[str, Dict[str, str]]:
     """
     Construct a prompt for distinguishing between multiple topics.

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -15,7 +15,65 @@ GET_TOPIC_NAME_REGEX = r'\{\s*"topic_name":\s*.*?,\s*"topic_specificity":\s*[\w.
 GET_TOPIC_CLUSTER_NAMES_REGEX = r'\{\s*"new_topic_name_mapping":\s*.*?,\s*"topic_specificities": .*?\}'
 
 PROMPT_TEMPLATES = {
-    "layer": jinja2.Template(
+    "layer": {
+        "system": jinja2.Template(
+            """
+You are an expert at classifying {{document_type}} from {{corpus_description}} into topics.
+Your task is to analyze information about a group of {{document_type}} and assign a {{summary_kind}} name to this group.
+The response must be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>}
+where NAME is the topic name you generate and SCORE is a float value between 0.0 and 1.0,
+representing how specific and well-defined the topic name is given the input information.
+A score of 1.0 means a perfectly descriptive and specific name, while 0.0 would be a completely generic or unrelated name.
+{% if is_very_specific_summary %}
+The topic name should be specific to the information given and sufficiently detailed to ensure
+it can be distinguished from other similarly detailed topics.
+{% elif is_general_summary %}
+The topic name should be broad and simple enough to capture the overall sense of the
+large and diverse range of {{document_type}} contained in it at a glance.
+{% endif %}
+{% if has_major_subtopics %}
+You should primarily make use of the major and minor subtopics of this group to generate a name,
+and ensure the topic name reflects the core essence of *all* major subtopics.
+{% endif %}
+Ensure your entire response is only the JSON object, with no other text before or after it.
+"""
+        ),
+        "user": jinja2.Template(
+            """
+Here is the information about the group of {{document_type}}:
+{% if cluster_keywords %}
+- Keywords for this group include: {{", ".join(cluster_keywords)}}
+{% endif %}
+{%- if cluster_subtopics["major"] %}
+- Major subtopics of this group are:
+{%- for subtopic in cluster_subtopics["major"] %}
+  * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_subtopics["minor"] %}
+- Minor subtopics of this group are:
+{%- for subtopic in cluster_subtopics["minor"] %}
+  * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_subtopics["misc"] %}
+- Other miscellaneous detailed subtopics of this group in order of relevance (from most to least) include:
+{%- for subtopic in cluster_subtopics["misc"] %}
+  * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_sentences %}
+- Sample {{document_type}} from this group include:
+{%- for sentence in cluster_sentences %}
+{{exemplar_start_delimiter}}{{sentence}}{{exemplar_end_delimiter}}
+{%- endfor %}
+{%- endif %}
+
+Based on this information, provide a {{summary_kind}} name for this group.
+Recall the output format: {"topic_name":<NAME>, "topic_specificity":<SCORE>}.
+"""
+        ),
+        "combined": jinja2.Template(
         """
 You are an expert of classifying {{document_type}} from {{corpus_description}} into topics.
 Below is a information about a group of {{document_type}} from {{corpus_description}} that 
@@ -50,22 +108,90 @@ are all on the same topic and need to be given topic name.
 {%- endif %}
 
 You are to give a {{summary_kind}} name to this group of {{document_type}}.
-{% if cluster_subtopics["major"] -%}
+{% if has_major_subtopics -%}
 You should primarily make use of the major and minor subtopics of this group to generate a name, 
 and ensure the topic name covers *all* of the major subtopics.
 {%- endif %}
-{% if "very specific" in summary_kind -%}
+{% if is_very_specific_summary -%}
 The topic name should be specific to the information given and sufficiently detailed to ensure 
 it can be distinguished from other similar detailed topics.
-{% elif "general" in summary_kind -%}
+{% elif is_general_summary -%}
 The topic name should be broad and simple enough to capture of overall sense of the 
 large and diverse range of {{document_type}} contained in it at a glance.
 {%- endif %}
 The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} 
 where SCORE is a value in the range 0 to 1.
 """
-    ),
-    "disambiguate_topics": jinja2.Template(
+        ),
+      },
+    "disambiguate_topics": {
+        "system": jinja2.Template(
+            """
+You are an expert in {{larger_topic}}. You have been asked to provide more specific and distinguishing names for various groups of
+{{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
+
+Your task is to generate a new {{summary_kind}} name for each topic group presented.
+You should make use of the relative relationships between these topics, their keywords, subtopic information, and sample {{document_type}} to generate new, distinct topic names.
+The new names must be in the same order as the original topics are presented.
+There should be no duplicate topic names in your final list of new names.
+
+{% if is_very_specific_summary %}
+Each new topic name should be specific to the information of that topic and sufficiently detailed to ensure it can be distinguished from all the other similar topics listed.
+{% elif is_general_summary %}
+Each topic name should be broad and simple enough to capture the overall sense of the large and diverse range of {{document_type}} contained in it at a glance, while still separating it from the other topics listed.
+{% endif %}
+{% if has_major_subtopics %}
+For each topic, you should primarily make use of its major and minor subtopics to generate a name, and ensure the new topic name reflects the core essence of *all* of its major subtopics.
+{% endif %}
+
+The response must be formatted as a single JSON object in the format:
+{"new_topic_name_mapping": {"1. OLD_NAME1": "NEW_NAME1", "2. OLD_NAME2": "NEW_NAME2", ... }, "topic_specificities": [NEW_TOPIC_SCORE1, NEW_TOPIC_SCORE2, ...]}
+where SCORE is a float value between 0.0 and 1.0 representing the quality and specificity of the new name.
+Ensure your entire response is only the JSON object, with no other text before or after it.
+"""
+        ),
+        "user": jinja2.Template(
+            """
+Below are the auto-generated topic names, along with keywords, subtopics, and sample {{document_type}} for each topic area.
+
+Original larger topic context: {{larger_topic}}
+Corpus description: {{corpus_description}}
+
+{% for topic in topics %}
+"{{loop.index}}. {{topic}}":
+{% if cluster_keywords[loop.index - 1] %}
+- Keywords for this group include: {{", ".join(cluster_keywords[loop.index - 1])}}
+{% endif %}
+{%- if cluster_subtopics["major"][loop.index - 1] %}
+- Major subtopics of this group are:
+{%- for subtopic in cluster_subtopics["major"][loop.index - 1] %}
+    * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_subtopics["minor"][loop.index - 1] %}
+- Minor subtopics of this group are:
+{%- for subtopic in cluster_subtopics["minor"][loop.index - 1] %}
+    * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_subtopics["misc"][loop.index - 1] %}
+- Other miscellaneous specific subtopics of this group in order of relevance (from most to least) include:
+{%- for subtopic in cluster_subtopics["misc"][loop.index - 1] %}
+    * {{subtopic}}
+{%- endfor %}
+{%- endif %}
+{%- if cluster_sentences[loop.index - 1] %}
+- Sample {{document_type}} from this group include:
+{%- for sentence in cluster_sentences[loop.index - 1] %}
+{{exemplar_start_delimiter}}{{sentence}}{{exemplar_end_delimiter}}
+{%- endfor %}
+{%- endif %}
+{% endfor %}
+
+Please provide new {{summary_kind}} names for each topic, following the JSON output format specified.
+"""
+        ),
+        "combined": jinja2.Template(
         """
 You are an expert in {{larger_topic}}, and have been asked to provide a more specific names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
@@ -121,5 +247,6 @@ The response should be formatted as JSON in the format
 where SCORE is a value in the range 0 to 1.
 The response must contain only JSON with no preamble and must have one entry for each topic to be renamed.
 """
-    ),
+      ),
+    },
 }

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -155,7 +155,7 @@ class Toponymy:
                 self.layer_class,
                 show_progress_bar=self.show_progress_bars,
                 exemplar_delimiters=self.exemplar_delimiters,
-                prompt_format="system_user" if self.llm_wrapper.supports_system_prompt else "combined",
+                prompt_format="system_user" if self.llm_wrapper.supports_system_prompts else "combined",
             )
 
         # Initialize other data structures

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -2,6 +2,7 @@ from toponymy.clustering import ToponymyClusterer, Clusterer
 from toponymy.keyphrases import KeyphraseBuilder
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from toponymy.topic_tree import TopicTree
+from toponymy.llm_wrappers import LLMWrapper
 
 from sentence_transformers import SentenceTransformer
 from sklearn.utils.validation import check_is_fitted
@@ -89,7 +90,7 @@ class Toponymy:
 
     def __init__(
         self,
-        llm_wrapper,
+        llm_wrapper: LLMWrapper,
         text_embedding_model: SentenceTransformer,
         clusterer: Clusterer = ToponymyClusterer(),
         layer_class: Type[ClusterLayer] = ClusterLayerText,
@@ -154,6 +155,7 @@ class Toponymy:
                 self.layer_class,
                 show_progress_bar=self.show_progress_bars,
                 exemplar_delimiters=self.exemplar_delimiters,
+                prompt_format="system_user" if self.llm_wrapper.supports_system_prompt else "combined",
             )
 
         # Initialize other data structures


### PR DESCRIPTION
Many LLMs support system prompting. By separating LLM instructions from actual content into system and user prompts we can get more robust performance from LLMs that support it. This PR breaks down the templates into either "system_user" or "combined", selects "system_user" based prompting if the LLM supports it, and allows all the LLM wrappers to use either kind of prompting if they can (so you can enforce combined prompting if you choose).