### PR TITLE
Fix OpenAI wrappers

### DIFF
--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -45,7 +45,7 @@ try:
         def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
             result = []
             for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
-                response = self.client.embeddings.create(texts=texts[i:i+96], model=self.model, encoding_format="float")
+                response = self.client.embeddings.create(input=texts[i:i+96], model=self.model, encoding_format="float")
                 result.append(np.asarray([item.embedding for item in response.data]))       
 
             return np.vstack(result)

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -1325,6 +1325,7 @@ try:
                         messages=[{"role": "user", "content": prompt + self.extra_prompting}],
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        response_format={"type": "json_object"},
                     )
                     return response.choices[0].message.content
             except Exception as e:
@@ -1345,6 +1346,7 @@ try:
                         ],
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        response_format={"type": "json_object"},
                     )
                     return response.choices[0].message.content
             except Exception as e:


### PR DESCRIPTION
I couldn't get the package to work without the following changes:

*I added `response_format={"type": "json_object"}` into the AsyncOpenAI API call for LLMs so that the output is always in the expected format (I got stuck with some hard-to-debug error message before making this change.)
* OpenAI's embedding client expects `input` instead of `texts` parameter so I made that change as well. (The embedder didn't work for me at all before I made this change.)