### PR TITLE
Fix/combine verbosity parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ your data ahead of time via:
 .. code-block:: python
 
     from toponymy import ToponymyClusterer
-    clusterer = ToponymyClusterer(min_clusters=4, verbosity=True)
+    clusterer = ToponymyClusterer(min_clusters=4, verbose=True)
     clusterer.fit(clusterable_vectors=document_map, embedding_vectors=document_vectors)
     for i, layer in enumerate(clusterer.cluster_layers_):
         print(f'{len(np.unique(layer.cluster_labels))-1} clusters in layer {i}')
@@ -111,7 +111,7 @@ for the documents in the data set using an ``embedding_model``, ``document_vecto
         object_description="newsgroup posts",
         corpus_description="20-newsgroups dataset",
         exemplar_delimiters=["<EXAMPLE_POST>\n","\n</EXAMPLE_POST>\n\n"],
-        verbosity=True,  # Show progress bars and informative messages
+        verbose=True,  # Show progress bars and informative messages
     )
     topic_model.fit(text, document_vectors, document_map)
 
@@ -211,27 +211,27 @@ Here is an example of using ``datamapplot`` to visualize your data:
 This will launch an interactive map in your browser or notebook environment, showing document clusters and their associated topic names across all hierarchical layers. You can zoom in to explore fine-grained topics and zoom out to see broader themes, enabling intuitive navigation of the information space.
 
 -----------------------------------
-Controlling Output Verbosity
+Controlling Verbose Output
 -----------------------------------
 
-Toponymy provides a unified ``verbosity`` parameter to control progress bars and informative messages across all components:
+Toponymy provides a unified ``verbose`` parameter to control progress bars and informative messages across all components:
 
 .. code-block:: python
 
     # Show all progress bars and messages
-    clusterer = ToponymyClusterer(min_clusters=4, verbosity=True)
+    clusterer = ToponymyClusterer(min_clusters=4, verbose=True)
     
     # Suppress all output for silent operation
-    clusterer = ToponymyClusterer(min_clusters=4, verbosity=False)
+    clusterer = ToponymyClusterer(min_clusters=4, verbose=False)
     
     # The same parameter works for all components
     topic_model = Toponymy(
         llm_wrapper=llm,
         text_embedding_model=embedding_model,
-        verbosity=True  # Shows progress for all operations
+        verbose=True  # Shows progress for all operations
     )
 
-The ``verbosity`` parameter replaces the older ``verbose`` and ``show_progress_bar`` parameters, providing a simpler and more consistent interface. Legacy parameters are still supported for backward compatibility but will show deprecation warnings.
+The ``verbose`` parameter unifies the older separate ``verbose`` and ``show_progress_bar`` parameters, providing a simpler and more consistent interface. Legacy parameters are still supported for backward compatibility but will show deprecation warnings.
 
 -------------------
 Vector Construction

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ your data ahead of time via:
 .. code-block:: python
 
     from toponymy import ToponymyClusterer
-    clusterer = ToponymyClusterer(min_clusters=4)
+    clusterer = ToponymyClusterer(min_clusters=4, verbosity=True)
     clusterer.fit(clusterable_vectors=document_map, embedding_vectors=document_vectors)
     for i, layer in enumerate(clusterer.cluster_layers_):
         print(f'{len(np.unique(layer.cluster_labels))-1} clusters in layer {i}')
@@ -111,6 +111,7 @@ for the documents in the data set using an ``embedding_model``, ``document_vecto
         object_description="newsgroup posts",
         corpus_description="20-newsgroups dataset",
         exemplar_delimiters=["<EXAMPLE_POST>\n","\n</EXAMPLE_POST>\n\n"],
+        verbosity=True,  # Show progress bars and informative messages
     )
     topic_model.fit(text, document_vectors, document_map)
 
@@ -209,7 +210,28 @@ Here is an example of using ``datamapplot`` to visualize your data:
 
 This will launch an interactive map in your browser or notebook environment, showing document clusters and their associated topic names across all hierarchical layers. You can zoom in to explore fine-grained topics and zoom out to see broader themes, enabling intuitive navigation of the information space.
 
+-----------------------------------
+Controlling Output Verbosity
+-----------------------------------
 
+Toponymy provides a unified ``verbosity`` parameter to control progress bars and informative messages across all components:
+
+.. code-block:: python
+
+    # Show all progress bars and messages
+    clusterer = ToponymyClusterer(min_clusters=4, verbosity=True)
+    
+    # Suppress all output for silent operation
+    clusterer = ToponymyClusterer(min_clusters=4, verbosity=False)
+    
+    # The same parameter works for all components
+    topic_model = Toponymy(
+        llm_wrapper=llm,
+        text_embedding_model=embedding_model,
+        verbosity=True  # Shows progress for all operations
+    )
+
+The ``verbosity`` parameter replaces the older ``verbose`` and ``show_progress_bar`` parameters, providing a simpler and more consistent interface. Legacy parameters are still supported for backward compatibility but will show deprecation warnings.
 
 -------------------
 Vector Construction

--- a/toponymy/_utils.py
+++ b/toponymy/_utils.py
@@ -1,0 +1,76 @@
+"""Utility functions for internal use."""
+
+import warnings
+from typing import Optional, Tuple
+
+
+def handle_verbosity_params(
+    verbosity: Optional[bool] = None,
+    verbose: Optional[bool] = None,
+    show_progress_bar: Optional[bool] = None,
+    show_progress_bars: Optional[bool] = None,
+    default_verbosity: bool = True,
+) -> Tuple[bool, bool]:
+    """
+    Handle the transition from verbose/show_progress_bar to unified verbosity parameter.
+    
+    Parameters
+    ----------
+    verbosity : bool, optional
+        New unified parameter. If True, shows both progress bars and verbose output.
+        If False, suppresses all output. Takes precedence over legacy parameters.
+    verbose : bool, optional
+        Legacy parameter for verbose output.
+    show_progress_bar : bool, optional
+        Legacy parameter for progress bar display.
+    show_progress_bars : bool, optional
+        Legacy parameter for progress bar display (used in Toponymy class).
+    default_verbosity : bool, default=True
+        Default value to use when no parameters are provided.
+    
+    Returns
+    -------
+    tuple of (bool, bool)
+        Returns (show_progress_bar, verbose) for internal use.
+    """
+    # If new verbosity parameter is provided, use it
+    if verbosity is not None:
+        return verbosity, verbosity
+    
+    # Handle legacy parameters
+    legacy_params_used = []
+    if verbose is not None:
+        legacy_params_used.append("verbose")
+    if show_progress_bar is not None:
+        legacy_params_used.append("show_progress_bar")
+    if show_progress_bars is not None:
+        legacy_params_used.append("show_progress_bars")
+    
+    # Issue deprecation warning if legacy parameters are used
+    if legacy_params_used:
+        params_str = ", ".join(legacy_params_used)
+        warnings.warn(
+            f"Parameters {params_str} are deprecated and will be removed in v2.0. "
+            f"Use 'verbosity' parameter instead. "
+            f"Set verbosity=True to show all output, verbosity=False to suppress all output.",
+            DeprecationWarning,
+            stacklevel=3
+        )
+    
+    # Determine values from legacy parameters
+    # show_progress_bars takes precedence over show_progress_bar for backward compatibility
+    progress_bar_value = show_progress_bars if show_progress_bars is not None else show_progress_bar
+    
+    # If only verbose is set to True, we should show progress bars too (expected behavior)
+    if verbose is True and progress_bar_value is None:
+        progress_bar_value = True
+    
+    # Use default if no legacy parameters provided
+    if verbose is None and progress_bar_value is None:
+        return default_verbosity, default_verbosity
+    
+    # Return the resolved values
+    return (
+        progress_bar_value if progress_bar_value is not None else default_verbosity,
+        verbose if verbose is not None else default_verbosity
+    )

--- a/toponymy/_utils.py
+++ b/toponymy/_utils.py
@@ -4,28 +4,28 @@ import warnings
 from typing import Optional, Tuple
 
 
-def handle_verbosity_params(
-    verbosity: Optional[bool] = None,
+def handle_verbose_params(
     verbose: Optional[bool] = None,
+    verbose_legacy: Optional[bool] = None,
     show_progress_bar: Optional[bool] = None,
     show_progress_bars: Optional[bool] = None,
-    default_verbosity: bool = True,
+    default_verbose: bool = True,
 ) -> Tuple[bool, bool]:
     """
-    Handle the transition from verbose/show_progress_bar to unified verbosity parameter.
+    Handle the transition from verbose/show_progress_bar to unified verbose parameter.
     
     Parameters
     ----------
-    verbosity : bool, optional
+    verbose : bool, optional
         New unified parameter. If True, shows both progress bars and verbose output.
         If False, suppresses all output. Takes precedence over legacy parameters.
-    verbose : bool, optional
-        Legacy parameter for verbose output.
+    verbose_legacy : bool, optional
+        Legacy parameter for verbose output (deprecated).
     show_progress_bar : bool, optional
         Legacy parameter for progress bar display.
     show_progress_bars : bool, optional
         Legacy parameter for progress bar display (used in Toponymy class).
-    default_verbosity : bool, default=True
+    default_verbose : bool, default=True
         Default value to use when no parameters are provided.
     
     Returns
@@ -33,13 +33,13 @@ def handle_verbosity_params(
     tuple of (bool, bool)
         Returns (show_progress_bar, verbose) for internal use.
     """
-    # If new verbosity parameter is provided, use it
-    if verbosity is not None:
-        return verbosity, verbosity
+    # If new verbose parameter is provided, use it
+    if verbose is not None:
+        return verbose, verbose
     
     # Handle legacy parameters
     legacy_params_used = []
-    if verbose is not None:
+    if verbose_legacy is not None:
         legacy_params_used.append("verbose")
     if show_progress_bar is not None:
         legacy_params_used.append("show_progress_bar")
@@ -51,8 +51,8 @@ def handle_verbosity_params(
         params_str = ", ".join(legacy_params_used)
         warnings.warn(
             f"Parameters {params_str} are deprecated and will be removed in v2.0. "
-            f"Use 'verbosity' parameter instead. "
-            f"Set verbosity=True to show all output, verbosity=False to suppress all output.",
+            f"Use 'verbose' parameter instead. "
+            f"Set verbose=True to show all output, verbose=False to suppress all output.",
             DeprecationWarning,
             stacklevel=3
         )
@@ -61,16 +61,16 @@ def handle_verbosity_params(
     # show_progress_bars takes precedence over show_progress_bar for backward compatibility
     progress_bar_value = show_progress_bars if show_progress_bars is not None else show_progress_bar
     
-    # If only verbose is set to True, we should show progress bars too (expected behavior)
-    if verbose is True and progress_bar_value is None:
+    # If only verbose_legacy is set to True, we should show progress bars too (expected behavior)
+    if verbose_legacy is True and progress_bar_value is None:
         progress_bar_value = True
     
     # Use default if no legacy parameters provided
-    if verbose is None and progress_bar_value is None:
-        return default_verbosity, default_verbosity
+    if verbose_legacy is None and progress_bar_value is None:
+        return default_verbose, default_verbose
     
     # Return the resolved values
     return (
-        progress_bar_value if progress_bar_value is not None else default_verbosity,
-        verbose if verbose is not None else default_verbosity
+        progress_bar_value if progress_bar_value is not None else default_verbose,
+        verbose_legacy if verbose_legacy is not None else default_verbose
     )

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -25,6 +25,7 @@ from toponymy.prompt_construction import (
 from sentence_transformers import SentenceTransformer
 from tqdm.auto import tqdm
 import asyncio
+from toponymy._utils import handle_verbosity_params
 
 
 def run_async(coro):
@@ -80,7 +81,8 @@ class ClusterLayer(ABC):
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
         prompt_format: str = "combined",
         prompt_template: Optional[str] = None,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
     ):
         self.cluster_labels = cluster_labels
         self.centroid_vectors = centroid_vectors
@@ -93,7 +95,14 @@ class ClusterLayer(ABC):
         self.exemplar_delimiters = exemplar_delimiters
         self.prompt_format = prompt_format
         self.prompt_template = prompt_template
-        self.show_progress_bar = show_progress_bar
+        
+        # Handle verbosity parameters
+        self.show_progress_bar, self.verbose = handle_verbosity_params(
+            verbosity=verbosity,
+            show_progress_bar=show_progress_bar,
+            default_verbosity=False
+        )
+        self.verbosity = self.show_progress_bar
 
         # Initialize empty lists for the cluster layer's attributes
         self.topic_names = []
@@ -327,7 +336,8 @@ class ClusterLayerText(ClusterLayer):
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
         prompt_format: str = "combined",
         prompt_template: Optional[str] = None,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -338,6 +348,7 @@ class ClusterLayerText(ClusterLayer):
             exemplar_delimiters=exemplar_delimiters,
             prompt_format=prompt_format,
             prompt_template=prompt_template,
+            verbosity=verbosity,
             show_progress_bar=show_progress_bar,
             **kwargs,
         )
@@ -509,6 +520,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 max_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "central":
@@ -520,6 +532,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 diversify_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "bm25":
@@ -531,6 +544,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 diversify_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method in ("saturated_coverage", "facility_location", "graph_cut"):
@@ -542,6 +556,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 n_keyphrases=self.n_keyphrases,
                 submodular_function=method,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         else:
@@ -569,6 +584,7 @@ class ClusterLayerText(ClusterLayer):
                 diversify_alpha=self.subtopic_diversify_alpha,
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "information_weighted":
@@ -580,6 +596,7 @@ class ClusterLayerText(ClusterLayer):
                 diversify_alpha=self.subtopic_diversify_alpha,
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method in ("saturated_coverage", "facility_location"):
@@ -591,6 +608,7 @@ class ClusterLayerText(ClusterLayer):
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
                 submodular_function=method,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         else:
@@ -616,6 +634,7 @@ class ClusterLayerText(ClusterLayer):
                 n_exemplars=self.n_exemplars,
                 diversify_alpha=self.exemplars_diversify_alpha,
                 object_to_text_function=self.object_to_text_function,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "facility_location" or method == "saturated_coverage":
@@ -626,6 +645,7 @@ class ClusterLayerText(ClusterLayer):
                 n_exemplars=self.n_exemplars,
                 object_to_text_function=self.object_to_text_function,
                 submodular_function=method,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "random":
@@ -634,6 +654,7 @@ class ClusterLayerText(ClusterLayer):
                 objects=object_list,
                 n_exemplars=self.n_exemplars,
                 object_to_text_function=self.object_to_text_function,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bar,
             )
         else:

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -25,7 +25,7 @@ from toponymy.prompt_construction import (
 from sentence_transformers import SentenceTransformer
 from tqdm.auto import tqdm
 import asyncio
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 
 def run_async(coro):
@@ -81,7 +81,7 @@ class ClusterLayer(ABC):
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
         prompt_format: str = "combined",
         prompt_template: Optional[str] = None,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
     ):
         self.cluster_labels = cluster_labels
@@ -96,13 +96,12 @@ class ClusterLayer(ABC):
         self.prompt_format = prompt_format
         self.prompt_template = prompt_template
         
-        # Handle verbosity parameters
-        self.show_progress_bar, self.verbose = handle_verbosity_params(
-            verbosity=verbosity,
+        # Handle verbose parameters
+        self.show_progress_bar, self.verbose = handle_verbose_params(
+            verbose=verbose,
             show_progress_bar=show_progress_bar,
-            default_verbosity=False
+            default_verbose=False
         )
-        self.verbosity = self.show_progress_bar
 
         # Initialize empty lists for the cluster layer's attributes
         self.topic_names = []
@@ -336,7 +335,7 @@ class ClusterLayerText(ClusterLayer):
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
         prompt_format: str = "combined",
         prompt_template: Optional[str] = None,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
         **kwargs: Any,
     ):
@@ -348,7 +347,7 @@ class ClusterLayerText(ClusterLayer):
             exemplar_delimiters=exemplar_delimiters,
             prompt_format=prompt_format,
             prompt_template=prompt_template,
-            verbosity=verbosity,
+            verbose=verbose,
             show_progress_bar=show_progress_bar,
             **kwargs,
         )
@@ -520,7 +519,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 max_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "central":
@@ -532,7 +531,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 diversify_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "bm25":
@@ -544,7 +543,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 diversify_alpha=self.keyphrase_diversify_alpha,
                 n_keyphrases=self.n_keyphrases,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method in ("saturated_coverage", "facility_location", "graph_cut"):
@@ -556,7 +555,7 @@ class ClusterLayerText(ClusterLayer):
                 embedding_model,
                 n_keyphrases=self.n_keyphrases,
                 submodular_function=method,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         else:
@@ -584,7 +583,7 @@ class ClusterLayerText(ClusterLayer):
                 diversify_alpha=self.subtopic_diversify_alpha,
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "information_weighted":
@@ -596,7 +595,7 @@ class ClusterLayerText(ClusterLayer):
                 diversify_alpha=self.subtopic_diversify_alpha,
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method in ("saturated_coverage", "facility_location"):
@@ -608,7 +607,7 @@ class ClusterLayerText(ClusterLayer):
                 n_subtopics=self.n_subtopics,
                 embedding_model=embedding_model,
                 submodular_function=method,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         else:
@@ -634,7 +633,7 @@ class ClusterLayerText(ClusterLayer):
                 n_exemplars=self.n_exemplars,
                 diversify_alpha=self.exemplars_diversify_alpha,
                 object_to_text_function=self.object_to_text_function,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "facility_location" or method == "saturated_coverage":
@@ -645,7 +644,7 @@ class ClusterLayerText(ClusterLayer):
                 n_exemplars=self.n_exemplars,
                 object_to_text_function=self.object_to_text_function,
                 submodular_function=method,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         elif method == "random":
@@ -654,7 +653,7 @@ class ClusterLayerText(ClusterLayer):
                 objects=object_list,
                 n_exemplars=self.n_exemplars,
                 object_to_text_function=self.object_to_text_function,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bar,
             )
         else:

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -13,7 +13,7 @@ from sklearn.neighbors import KDTree
 from typing import List, Tuple, Dict, Type, Any, Optional
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from typing import List, Tuple, Dict, Type, Any, Optional, NewType
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 from sklearn.cluster import KMeans
 
@@ -100,7 +100,6 @@ def build_raw_cluster_layers(
     base_n_clusters: Optional[int] = None,
     next_cluster_size_quantile: float = 0.8,
     max_layers: Optional[int] = None,
-    verbosity: bool = None,
     verbose: bool = None,
 ) -> List[np.ndarray]:
     """
@@ -159,11 +158,10 @@ def build_raw_cluster_layers(
             "Try reducing base_min_cluster_size."
         )
 
-    # Handle verbosity parameters
-    _, verbose_output = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    _, verbose_output = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        default_verbose=False
     )
 
     while n_clusters_in_layer >= min_clusters:
@@ -276,9 +274,8 @@ def create_cluster_layers(
     base_n_clusters: Optional[int] = None,
     next_cluster_size_quantile: float = 0.8,
     max_layers: Optional[int] = None,
-    verbosity: bool = None,
-    show_progress_bar: bool = None,
     verbose: bool = None,
+    show_progress_bar: bool = None,
     **layer_kwargs,
 ) -> Tuple[List[ClusterLayer], ClusterTree]:
     """
@@ -305,12 +302,10 @@ def create_cluster_layers(
         The quantile value to determine the size of the minimum cluster size for the next layer (default is 0.8).
     max_layers : Optional[int], optional
         The maximum number of layers to create (default is None). If None, no limit is imposed.
-    verbosity : bool, optional
+    verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
     show_progress_bar : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
-    verbose : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
+        Deprecated. Use verbose instead.
     **layer_kwargs : Any
         Any additional keyword arguments to be passed to the layer class.
 
@@ -319,12 +314,11 @@ def create_cluster_layers(
     Tuple[List[Any], Dict[Tuple[int, int], List[Tuple[int, int]]]]
         A tuple containing a list of created layers and a dictionary representing the cluster tree.
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, verbose_val = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, verbose_val = handle_verbose_params(
         verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
     
     cluster_labels = build_raw_cluster_layers(
@@ -335,7 +329,6 @@ def create_cluster_layers(
         base_n_clusters=base_n_clusters,
         next_cluster_size_quantile=next_cluster_size_quantile,
         max_layers=max_layers,
-        verbosity=show_progress_bar_val,
         verbose=verbose_val,
     )
     cluster_tree = build_cluster_tree(cluster_labels)
@@ -344,7 +337,7 @@ def create_cluster_layers(
             labels,
             centroids_from_labels(labels, embedding_vectors),
             layer_id=i,
-            verbosity=show_progress_bar_val,
+            verbose=show_progress_bar_val,
             show_progress_bar=show_progress_bar_val,
             **layer_kwargs,
         )
@@ -398,12 +391,10 @@ class ToponymyClusterer(Clusterer):
         The quantile value to determine the size of the minimum cluster size for the next layer (default is 0.8).
     max_layers : Optional[int], optional
         The maximum number of layers to create (default is None). If None, no limit is imposed.
-    verbosity : bool, optional
+    verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
-    verbose : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
     show_progress_bar : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
+        Deprecated. Use verbose instead.
 
     Attributes
     ----------
@@ -422,7 +413,6 @@ class ToponymyClusterer(Clusterer):
         base_n_clusters: Optional[int] = None,
         next_cluster_size_quantile: float = 0.85,
         max_layers: Optional[int] = None,
-        verbosity: bool = None,
         verbose: bool = None,
         show_progress_bar: bool = None,
     ):
@@ -434,14 +424,12 @@ class ToponymyClusterer(Clusterer):
         self.next_cluster_size_quantile = next_cluster_size_quantile
         self.max_layers = max_layers
         
-        # Handle verbosity parameters
-        _, self.verbose = handle_verbosity_params(
-            verbosity=verbosity,
+        # Handle verbose parameters
+        _, self.verbose = handle_verbose_params(
             verbose=verbose,
             show_progress_bar=show_progress_bar,
-            default_verbosity=False
+            default_verbose=False
         )
-        self.verbosity = self.verbose
 
         if self.base_min_cluster_size is None and self.base_n_clusters is None:
             raise ValueError(
@@ -453,7 +441,7 @@ class ToponymyClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Clusterer:
@@ -467,9 +455,8 @@ class ToponymyClusterer(Clusterer):
             base_n_clusters=self.base_n_clusters,
             next_cluster_size_quantile=self.next_cluster_size_quantile,
             max_layers=self.max_layers,
-            verbosity=verbosity if verbosity is not None else self.verbosity,
+            verbose=verbose if verbose is not None else self.verbose,
             show_progress_bar=show_progress_bar,
-            verbose=verbosity if verbosity is not None else self.verbose,
             **layer_kwargs,
         )
         return self
@@ -479,7 +466,7 @@ class ToponymyClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Tuple[List[ClusterLayer], ClusterTree]:
@@ -487,7 +474,7 @@ class ToponymyClusterer(Clusterer):
             clusterable_vectors,
             embedding_vectors,
             layer_class=layer_class,
-            verbosity=verbosity,
+            verbose=verbose,
             show_progress_bar=show_progress_bar,
             **layer_kwargs,
         )
@@ -517,35 +504,33 @@ class KMeansClusterer(Clusterer):
     """
 
     def __init__(
-        self, min_clusters: int = 6, base_n_clusters: int = 1024, verbosity: bool = None, verbose: bool = None, show_progress_bar: bool = None
+        self, min_clusters: int = 6, base_n_clusters: int = 1024, verbose: bool = None, show_progress_bar: bool = None
     ):
         super().__init__()
         self.min_clusters = min_clusters
         self.base_n_clusters = base_n_clusters
         
-        # Handle verbosity parameters
-        _, self.verbose = handle_verbosity_params(
-            verbosity=verbosity,
+        # Handle verbose parameters
+        _, self.verbose = handle_verbose_params(
             verbose=verbose,
             show_progress_bar=show_progress_bar,
-            default_verbosity=False
+            default_verbose=False
         )
-        self.verbosity = self.verbose
 
     def fit(
         self,
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Clusterer:
-        # Handle verbosity parameters
-        _, verbose_output = handle_verbosity_params(
-            verbosity=verbosity if verbosity is not None else self.verbosity,
+        # Handle verbose parameters
+        _, verbose_output = handle_verbose_params(
+            verbose=verbose if verbose is not None else self.verbose,
             show_progress_bar=show_progress_bar,
-            default_verbosity=False
+            default_verbose=False
         )
         
         n_clusters = self.base_n_clusters
@@ -565,7 +550,7 @@ class KMeansClusterer(Clusterer):
                 labels,
                 centroids_from_labels(labels, embedding_vectors),
                 layer_id=i,
-                verbosity=verbosity,
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
                 **layer_kwargs,
             )
@@ -578,11 +563,11 @@ class KMeansClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Tuple[List[ClusterLayer], ClusterTree]:
-        self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbosity=verbosity, show_progress_bar=show_progress_bar, **layer_kwargs)
+        self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbose=verbose, show_progress_bar=show_progress_bar, **layer_kwargs)
         return self.cluster_layers_, self.cluster_tree_
 
 
@@ -605,7 +590,6 @@ try:
             symmetrize_graph: bool = True,
             node_embedding_dim: Optional[int] = None,
             neighbor_scale: float = 1.0,
-            verbosity: bool = None,
             verbose: bool = None,
             show_progress_bar: bool = None,
         ):
@@ -624,14 +608,12 @@ try:
             self.node_embedding_dim = node_embedding_dim
             self.neighbor_scale = neighbor_scale
             
-            # Handle verbosity parameters
-            _, self.verbose = handle_verbosity_params(
-                verbosity=verbosity,
+            # Handle verbose parameters
+            _, self.verbose = handle_verbose_params(
                 verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
-            self.verbosity = self.verbose
 
             self.evoc = evoc.EVoC(
                 noise_level=noise_level,
@@ -653,7 +635,7 @@ try:
             clusterable_vectors: np.ndarray,
             embedding_vectors: np.ndarray,
             layer_class: Type[ClusterLayer] = ClusterLayerText,
-            verbosity: bool = None,
+            verbose: bool = None,
             show_progress_bar: bool = None,
         ) -> Clusterer:
             self.evoc.fit(embedding_vectors)
@@ -664,7 +646,7 @@ try:
                     labels,
                     centroids_from_labels(labels, embedding_vectors),
                     layer_id=i,
-                    verbosity=verbosity,
+                    verbose=verbose,
                     show_progress_bar=show_progress_bar,
                 )
                 for i, labels in enumerate(cluster_labels)
@@ -676,10 +658,10 @@ try:
             clusterable_vectors: np.ndarray,
             embedding_vectors: np.ndarray,
             layer_class: Type[ClusterLayer] = ClusterLayerText,
-            verbosity: bool = None,
+            verbose: bool = None,
             show_progress_bar: bool = None,
         ) -> Tuple[List[ClusterLayer], ClusterTree]:
-            self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbosity=verbosity, show_progress_bar=show_progress_bar)
+            self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbose=verbose, show_progress_bar=show_progress_bar)
             return self.cluster_layers_, self.cluster_tree_
 
 except ImportError:

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -469,7 +469,7 @@ class ToponymyClusterer(Clusterer):
             max_layers=self.max_layers,
             verbosity=verbosity if verbosity is not None else self.verbosity,
             show_progress_bar=show_progress_bar,
-            verbose=self.verbose,
+            verbose=verbosity if verbosity is not None else self.verbose,
             **layer_kwargs,
         )
         return self

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -13,6 +13,7 @@ from sklearn.neighbors import KDTree
 from typing import List, Tuple, Dict, Type, Any, Optional
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from typing import List, Tuple, Dict, Type, Any, Optional, NewType
+from toponymy._utils import handle_verbosity_params
 
 from sklearn.cluster import KMeans
 
@@ -99,7 +100,8 @@ def build_raw_cluster_layers(
     base_n_clusters: Optional[int] = None,
     next_cluster_size_quantile: float = 0.8,
     max_layers: Optional[int] = None,
-    verbose=False,
+    verbosity: bool = None,
+    verbose: bool = None,
 ) -> List[np.ndarray]:
     """
     Build hierarchical cluster layers from raw data using a KDTree and Boruvka's algorithm.
@@ -157,10 +159,17 @@ def build_raw_cluster_layers(
             "Try reducing base_min_cluster_size."
         )
 
+    # Handle verbosity parameters
+    _, verbose_output = handle_verbosity_params(
+        verbosity=verbosity,
+        verbose=verbose,
+        default_verbosity=False
+    )
+
     while n_clusters_in_layer >= min_clusters:
         if max_layers is not None and len(cluster_layers) >= max_layers:
             break
-        if verbose:
+        if verbose_output:
             print(f"Layer {len(cluster_layers)} found {n_clusters_in_layer} clusters")
         cluster_layers.append(clusters)
         cluster_sizes = np.bincount(clusters[clusters >= 0])
@@ -267,8 +276,9 @@ def create_cluster_layers(
     base_n_clusters: Optional[int] = None,
     next_cluster_size_quantile: float = 0.8,
     max_layers: Optional[int] = None,
-    show_progress_bar: bool = False,
-    verbose: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
+    verbose: bool = None,
     **layer_kwargs,
 ) -> Tuple[List[ClusterLayer], ClusterTree]:
     """
@@ -295,10 +305,12 @@ def create_cluster_layers(
         The quantile value to determine the size of the minimum cluster size for the next layer (default is 0.8).
     max_layers : Optional[int], optional
         The maximum number of layers to create (default is None). If None, no limit is imposed.
-    show_progress_bar : bool, optional
-        Whether to show a progress bar (default is False).
-    verbose : bool, optional
-        Whether to show verbose output (default is False).
+    verbosity : bool, optional
+        Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
+    show_progress_bar : bool, optional, deprecated
+        Deprecated. Use verbosity instead.
+    verbose : bool, optional, deprecated
+        Deprecated. Use verbosity instead.
     **layer_kwargs : Any
         Any additional keyword arguments to be passed to the layer class.
 
@@ -307,6 +319,14 @@ def create_cluster_layers(
     Tuple[List[Any], Dict[Tuple[int, int], List[Tuple[int, int]]]]
         A tuple containing a list of created layers and a dictionary representing the cluster tree.
     """
+    # Handle verbosity parameters
+    show_progress_bar_val, verbose_val = handle_verbosity_params(
+        verbosity=verbosity,
+        verbose=verbose,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+    
     cluster_labels = build_raw_cluster_layers(
         clusterable_vectors,
         min_clusters=min_clusters,
@@ -315,7 +335,8 @@ def create_cluster_layers(
         base_n_clusters=base_n_clusters,
         next_cluster_size_quantile=next_cluster_size_quantile,
         max_layers=max_layers,
-        verbose=verbose,
+        verbosity=show_progress_bar_val,
+        verbose=verbose_val,
     )
     cluster_tree = build_cluster_tree(cluster_labels)
     layers = [
@@ -323,7 +344,8 @@ def create_cluster_layers(
             labels,
             centroids_from_labels(labels, embedding_vectors),
             layer_id=i,
-            show_progress_bar=show_progress_bar,
+            verbosity=show_progress_bar_val,
+            show_progress_bar=show_progress_bar_val,
             **layer_kwargs,
         )
         for i, labels in enumerate(cluster_labels)
@@ -376,8 +398,12 @@ class ToponymyClusterer(Clusterer):
         The quantile value to determine the size of the minimum cluster size for the next layer (default is 0.8).
     max_layers : Optional[int], optional
         The maximum number of layers to create (default is None). If None, no limit is imposed.
-    verbose : bool, optional
-        Whether to show verbose output (default is False).
+    verbosity : bool, optional
+        Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
+    verbose : bool, optional, deprecated
+        Deprecated. Use verbosity instead.
+    show_progress_bar : bool, optional, deprecated
+        Deprecated. Use verbosity instead.
 
     Attributes
     ----------
@@ -396,7 +422,9 @@ class ToponymyClusterer(Clusterer):
         base_n_clusters: Optional[int] = None,
         next_cluster_size_quantile: float = 0.85,
         max_layers: Optional[int] = None,
-        verbose=False,
+        verbosity: bool = None,
+        verbose: bool = None,
+        show_progress_bar: bool = None,
     ):
         super().__init__()
         self.min_clusters = min_clusters
@@ -405,7 +433,15 @@ class ToponymyClusterer(Clusterer):
         self.base_n_clusters = base_n_clusters
         self.next_cluster_size_quantile = next_cluster_size_quantile
         self.max_layers = max_layers
-        self.verbose = verbose
+        
+        # Handle verbosity parameters
+        _, self.verbose = handle_verbosity_params(
+            verbosity=verbosity,
+            verbose=verbose,
+            show_progress_bar=show_progress_bar,
+            default_verbosity=False
+        )
+        self.verbosity = self.verbose
 
         if self.base_min_cluster_size is None and self.base_n_clusters is None:
             raise ValueError(
@@ -417,7 +453,8 @@ class ToponymyClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Clusterer:
         self.cluster_layers_, self.cluster_tree_ = create_cluster_layers(
@@ -430,6 +467,7 @@ class ToponymyClusterer(Clusterer):
             base_n_clusters=self.base_n_clusters,
             next_cluster_size_quantile=self.next_cluster_size_quantile,
             max_layers=self.max_layers,
+            verbosity=verbosity if verbosity is not None else self.verbosity,
             show_progress_bar=show_progress_bar,
             verbose=self.verbose,
             **layer_kwargs,
@@ -441,13 +479,15 @@ class ToponymyClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Tuple[List[ClusterLayer], ClusterTree]:
         self.fit(
             clusterable_vectors,
             embedding_vectors,
             layer_class=layer_class,
+            verbosity=verbosity,
             show_progress_bar=show_progress_bar,
             **layer_kwargs,
         )
@@ -477,26 +517,42 @@ class KMeansClusterer(Clusterer):
     """
 
     def __init__(
-        self, min_clusters: int = 6, base_n_clusters: int = 1024, verbose=False
+        self, min_clusters: int = 6, base_n_clusters: int = 1024, verbosity: bool = None, verbose: bool = None, show_progress_bar: bool = None
     ):
         super().__init__()
         self.min_clusters = min_clusters
         self.base_n_clusters = base_n_clusters
-        self.verbose = verbose
+        
+        # Handle verbosity parameters
+        _, self.verbose = handle_verbosity_params(
+            verbosity=verbosity,
+            verbose=verbose,
+            show_progress_bar=show_progress_bar,
+            default_verbosity=False
+        )
+        self.verbosity = self.verbose
 
     def fit(
         self,
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Clusterer:
+        # Handle verbosity parameters
+        _, verbose_output = handle_verbosity_params(
+            verbosity=verbosity if verbosity is not None else self.verbosity,
+            show_progress_bar=show_progress_bar,
+            default_verbosity=False
+        )
+        
         n_clusters = self.base_n_clusters
         cluster_label_layers = []
 
         while n_clusters >= self.min_clusters:
-            if self.verbose:
+            if verbose_output:
                 print(f"Layer {len(cluster_label_layers)} found {n_clusters} clusters")
             kmeans = KMeans(n_clusters=n_clusters)
             cluster_labels = kmeans.fit_predict(clusterable_vectors)
@@ -509,6 +565,7 @@ class KMeansClusterer(Clusterer):
                 labels,
                 centroids_from_labels(labels, embedding_vectors),
                 layer_id=i,
+                verbosity=verbosity,
                 show_progress_bar=show_progress_bar,
                 **layer_kwargs,
             )
@@ -521,10 +578,11 @@ class KMeansClusterer(Clusterer):
         clusterable_vectors: np.ndarray,
         embedding_vectors: np.ndarray,
         layer_class: Type[ClusterLayer] = ClusterLayerText,
-        show_progress_bar: bool = False,
+        verbosity: bool = None,
+        show_progress_bar: bool = None,
         **layer_kwargs,
     ) -> Tuple[List[ClusterLayer], ClusterTree]:
-        self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, show_progress_bar=show_progress_bar, **layer_kwargs)
+        self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbosity=verbosity, show_progress_bar=show_progress_bar, **layer_kwargs)
         return self.cluster_layers_, self.cluster_tree_
 
 
@@ -547,6 +605,9 @@ try:
             symmetrize_graph: bool = True,
             node_embedding_dim: Optional[int] = None,
             neighbor_scale: float = 1.0,
+            verbosity: bool = None,
+            verbose: bool = None,
+            show_progress_bar: bool = None,
         ):
             super().__init__()
 
@@ -562,6 +623,15 @@ try:
             self.symmetrize_graph = symmetrize_graph
             self.node_embedding_dim = node_embedding_dim
             self.neighbor_scale = neighbor_scale
+            
+            # Handle verbosity parameters
+            _, self.verbose = handle_verbosity_params(
+                verbosity=verbosity,
+                verbose=verbose,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            self.verbosity = self.verbose
 
             self.evoc = evoc.EVoC(
                 noise_level=noise_level,
@@ -583,7 +653,8 @@ try:
             clusterable_vectors: np.ndarray,
             embedding_vectors: np.ndarray,
             layer_class: Type[ClusterLayer] = ClusterLayerText,
-            show_progress_bar: bool = False,
+            verbosity: bool = None,
+            show_progress_bar: bool = None,
         ) -> Clusterer:
             self.evoc.fit(embedding_vectors)
             cluster_labels = self.evoc.cluster_layers_
@@ -593,6 +664,7 @@ try:
                     labels,
                     centroids_from_labels(labels, embedding_vectors),
                     layer_id=i,
+                    verbosity=verbosity,
                     show_progress_bar=show_progress_bar,
                 )
                 for i, labels in enumerate(cluster_labels)
@@ -604,8 +676,10 @@ try:
             clusterable_vectors: np.ndarray,
             embedding_vectors: np.ndarray,
             layer_class: Type[ClusterLayer] = ClusterLayerText,
+            verbosity: bool = None,
+            show_progress_bar: bool = None,
         ) -> Tuple[List[ClusterLayer], ClusterTree]:
-            self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class)
+            self.fit(clusterable_vectors, embedding_vectors, layer_class=layer_class, verbosity=verbosity, show_progress_bar=show_progress_bar)
             return self.cluster_layers_, self.cluster_tree_
 
 except ImportError:

--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -5,6 +5,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
 
 
 from typing import Optional, List
+from toponymy._utils import handle_verbosity_params
 
 # Cohere
 try:
@@ -19,9 +20,16 @@ try:
             self.input_type="search_query" # We will be embedding keyphrases and subtopic names to match against documents
             self.embedding_types=['float']
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 response = self.co.embed(texts=texts[i:i+96], model=self.model, input_type=self.input_type, embedding_types=self.embedding_types)
                 result.append(np.asarray(response.embeddings.float_))
 
@@ -42,9 +50,16 @@ try:
             self.base_url = base_url
             self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 response = self.client.embeddings.create(input=texts[i:i+96], model=self.model, encoding_format="float")
                 result.append(np.asarray([item.embedding for item in response.data]))       
 
@@ -64,9 +79,16 @@ try:
             self.base_url = base_url
             self.httpx_client = httpx_client
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 batch = texts[i:i+96]
                 # Anthropic embeddings are done one at a time in the current API
                 batch_embeddings = []
@@ -108,10 +130,17 @@ try:
             assert len(embeddings) == len(texts)
             return np.array(embeddings)
 
-        def encode(self, texts: list, show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: list, verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
             
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 embeddings = self._encode_batch(texts[i:i+96])
                 result.append(embeddings)
             
@@ -129,9 +158,16 @@ try:
             self.client = mistralai.client.MistralClient(api_key=api_key)
             self.model = model
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 response = self.client.embeddings(
                     model=self.model,
                     inputs=texts[i:i+96]
@@ -156,9 +192,16 @@ try:
                 "Content-Type": "application/json"
             }
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
             result = []
-            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar)):
+            for i in tqdm(range(0, len(texts), 96), desc="embedding texts", disable=(not show_progress_bar_val)):
                 response = requests.post(
                     self.base_url,
                     headers=self.headers,
@@ -183,8 +226,15 @@ try:
         def __init__(self, model: str = "all-MiniLM-L6-v2", kwargs: dict = {}):
             self.llm = vllm.LLM(model=model, task='embed', **kwargs)
 
-        def encode(self, texts: List[str], show_progress_bar: bool = False) -> np.ndarray:
-            outputs = self.llm.embed(texts, use_tqdm=show_progress_bar)
+        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbosity parameters
+            show_progress_bar_val, _ = handle_verbosity_params(
+                verbosity=verbosity,
+                show_progress_bar=show_progress_bar,
+                default_verbosity=False
+            )
+            
+            outputs = self.llm.embed(texts, use_tqdm=show_progress_bar_val)
             embeddings = np.vstack([o.outputs.embedding for o in outputs])
             return embeddings
         

--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -5,7 +5,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
 
 
 from typing import Optional, List
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 # Cohere
 try:
@@ -20,12 +20,12 @@ try:
             self.input_type="search_query" # We will be embedding keyphrases and subtopic names to match against documents
             self.embedding_types=['float']
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -50,12 +50,12 @@ try:
             self.base_url = base_url
             self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -79,12 +79,12 @@ try:
             self.base_url = base_url
             self.httpx_client = httpx_client
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -130,12 +130,12 @@ try:
             assert len(embeddings) == len(texts)
             return np.array(embeddings)
 
-        def encode(self, texts: list, verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: list, verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -158,12 +158,12 @@ try:
             self.client = mistralai.client.MistralClient(api_key=api_key)
             self.model = model
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -192,12 +192,12 @@ try:
                 "Content-Type": "application/json"
             }
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             result = []
@@ -226,12 +226,12 @@ try:
         def __init__(self, model: str = "all-MiniLM-L6-v2", kwargs: dict = {}):
             self.llm = vllm.LLM(model=model, task='embed', **kwargs)
 
-        def encode(self, texts: List[str], verbosity: bool = None, show_progress_bar: bool = None) -> np.ndarray:
-            # Handle verbosity parameters
-            show_progress_bar_val, _ = handle_verbosity_params(
-                verbosity=verbosity,
+        def encode(self, texts: List[str], verbose: bool = None, show_progress_bar: bool = None) -> np.ndarray:
+            # Handle verbose parameters
+            show_progress_bar_val, _ = handle_verbose_params(
+                verbose=verbose,
                 show_progress_bar=show_progress_bar,
-                default_verbosity=False
+                default_verbose=False
             )
             
             outputs = self.llm.embed(texts, use_tqdm=show_progress_bar_val)

--- a/toponymy/exemplar_texts.py
+++ b/toponymy/exemplar_texts.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, FrozenSet, Dict, Callable, Any
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import KNeighborsTransformer
 from toponymy.utility_functions import diversify_max_alpha as diversify
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 from tqdm.auto import tqdm
 
@@ -321,7 +321,7 @@ def submodular_selection_exemplars(
     n_exemplars: int = 4,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
     submodular_function: str = "facility_location",
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar text for each cluster in a cluster layer.
@@ -373,11 +373,11 @@ def submodular_selection_exemplars(
             f"selection_function={submodular_function} is not a valid selection. Please choose one of (facility_location,saturated_coverage)"
         )
 
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     for cluster_num in tqdm(
@@ -434,7 +434,7 @@ def random_exemplars(
     objects: List[str],
     n_exemplars: int = 4,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar texts for each cluster in a cluster layer.
@@ -461,11 +461,11 @@ def random_exemplars(
         - A list of lists of exemplar texts for each cluster
         - A list of lists of indices indicating the position of each exemplar in the original object list
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     results = []
@@ -515,7 +515,7 @@ def diverse_exemplars(
     diversify_alpha: float = 1.0,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
     method: str = "centroid",
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar text for each cluster in a cluster layer.
@@ -550,11 +550,11 @@ def diverse_exemplars(
         - A list of lists of exemplar texts for each cluster
         - A list of lists of indices indicating the position of each exemplar in the original object list
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
     
     results = []

--- a/toponymy/exemplar_texts.py
+++ b/toponymy/exemplar_texts.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, FrozenSet, Dict, Callable, Any
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import KNeighborsTransformer
 from toponymy.utility_functions import diversify_max_alpha as diversify
+from toponymy._utils import handle_verbosity_params
 
 from tqdm.auto import tqdm
 
@@ -320,7 +321,8 @@ def submodular_selection_exemplars(
     n_exemplars: int = 4,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
     submodular_function: str = "facility_location",
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar text for each cluster in a cluster layer.
     These exemplars are selected to be the closest vectors to the cluster centroid while retaining
@@ -371,10 +373,17 @@ def submodular_selection_exemplars(
             f"selection_function={submodular_function} is not a valid selection. Please choose one of (facility_location,saturated_coverage)"
         )
 
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc=f"Selecting {submodular_function} exemplars",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
         unit="cluster",
         leave=False,
         position=1,
@@ -425,7 +434,8 @@ def random_exemplars(
     objects: List[str],
     n_exemplars: int = 4,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar texts for each cluster in a cluster layer.
     These exemplars are randomly sampled from each cluster.
@@ -451,13 +461,19 @@ def random_exemplars(
         - A list of lists of exemplar texts for each cluster
         - A list of lists of indices indicating the position of each exemplar in the original object list
     """
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
 
     results = []
     indices = []
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc="Selecting random exemplars",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
         unit="cluster",
         leave=False,
         position=1,
@@ -499,7 +515,8 @@ def diverse_exemplars(
     diversify_alpha: float = 1.0,
     object_to_text_function: Callable[List[Any], List[str]] = lambda x: x,
     method: str = "centroid",
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> Tuple[List[List[str]], List[List[int]]]:
     """Generates a list of exemplar text for each cluster in a cluster layer.
     These exemplars are selected to be the closest vectors to the cluster centroid while retaining
@@ -533,6 +550,13 @@ def diverse_exemplars(
         - A list of lists of exemplar texts for each cluster
         - A list of lists of indices indicating the position of each exemplar in the original object list
     """
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+    
     results = []
     indices = []
     null_topic = np.mean(object_vectors, axis=0)
@@ -540,7 +564,7 @@ def diverse_exemplars(
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc="Selecting central exemplars",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
         unit="cluster",
         leave=False,
         position=1,

--- a/toponymy/keyphrases.py
+++ b/toponymy/keyphrases.py
@@ -10,7 +10,7 @@ from vectorizers.transformers import InformationWeightTransformer
 from sklearn.metrics import pairwise_distances
 from apricot import SaturatedCoverageSelection, GraphCutSelection
 from toponymy.exemplar_texts import FacilityLocationSelection
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 from sentence_transformers import SentenceTransformer
 
@@ -169,7 +169,6 @@ def build_keyphrase_vocabulary(
     stop_words: FrozenSet[str] = ENGLISH_STOP_WORDS,
     n_jobs: int = -1,
     min_chunk_size: int = 20_000,
-    verbosity: bool = None,
     verbose: bool = None,
 ) -> List[str]:
     """
@@ -191,10 +190,8 @@ def build_keyphrase_vocabulary(
         The number of jobs to use in parallel processing, by default -1. If -1, all available cores are used.
     min_chunk_size : int, optional
         The minimum chunk size for parallel processing, by default 20_000.
-    verbosity : bool, optional
+    verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
-    verbose : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
 
     Returns
     -------
@@ -246,7 +243,6 @@ def build_keyphrase_count_matrix(
     ngrammer: Ngrammer,
     n_jobs: int = -1,
     min_chunk_size: int = 20_000,
-    verbosity: bool = None,
     verbose: bool = None,
 ) -> scipy.sparse.spmatrix:
     """
@@ -264,10 +260,8 @@ def build_keyphrase_count_matrix(
          The number of jobs to use in parallel processing, by default -1. If -1, all available cores are used.
      min_chunk_size : int, optional
          The minimum chunk size for parallel processing, by default 20_000.
-     verbosity : bool, optional
+     verbose : bool, optional
          Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
-     verbose : bool, optional, deprecated
-         Deprecated. Use verbosity instead.
 
 
      Returns
@@ -275,11 +269,10 @@ def build_keyphrase_count_matrix(
      scipy.sparse.spmatrix
          A sparse count matrix of keyphrases in the objects.
     """
-    # Handle verbosity parameters
-    _, verbose_output = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    _, verbose_output = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        default_verbose=False
     )
     
     # count ngrams in parallel with joblib
@@ -313,7 +306,6 @@ def build_object_x_keyphrase_matrix(
     stop_words: FrozenSet[str] = ENGLISH_STOP_WORDS,
     n_jobs: int = -1,
     min_chunk_size: int = 20_000,
-    verbosity: bool = None,
     verbose: bool = None,
 ) -> scipy.sparse.spmatrix:
     """
@@ -339,10 +331,8 @@ def build_object_x_keyphrase_matrix(
         The number of jobs to use in parallel processing, by default -1. If -1, all available cores are used.
     min_chunk_size : int, optional
         The minimum chunk size for parallel processing, by default 20_000.
-    verbosity : bool, optional
+    verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
-    verbose : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
 
     Returns
     -------
@@ -378,7 +368,6 @@ def build_object_x_keyphrase_matrix(
         keyphrase_dict,
         ngrammer=ngrammer,
         n_jobs=n_jobs,
-        verbosity=verbosity,
         verbose=verbose,
     )
 
@@ -425,11 +414,8 @@ class KeyphraseBuilder:
     embedder : Optional[SentenceTransformer], optional
         An optional embedder to generate keyphrase vectors, by default None.
     
-    verbosity : bool, optional
+    verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
-    
-    verbose : bool, optional, deprecated
-        Deprecated. Use verbosity instead.
 
     Attributes
     ----------
@@ -453,7 +439,6 @@ class KeyphraseBuilder:
         stop_words: FrozenSet[str] = ENGLISH_STOP_WORDS,
         n_jobs: int = -1,
         embedder: Optional[SentenceTransformer] = None,
-        verbosity: bool = None,
         verbose: bool = None,
     ):
         self.object_to_text = object_to_text
@@ -466,13 +451,11 @@ class KeyphraseBuilder:
         self.n_jobs = n_jobs
         self.embedder = embedder
         
-        # Handle verbosity parameters
-        _, self.verbose = handle_verbosity_params(
-            verbosity=verbosity,
+        # Handle verbose parameters
+        _, self.verbose = handle_verbose_params(
             verbose=verbose,
-            default_verbosity=False
+            default_verbose=False
         )
-        self.verbosity = self.verbose
 
     def fit(self, objects: List[Any]):
         if self.object_to_text is None:
@@ -572,9 +555,8 @@ def information_weighted_keyphrases(
     max_alpha: float = 1.0,
     min_alpha: float = 0.5,
     alpha_tolerance: float = 0.1,
-    verbosity: bool = None,
-    show_progress_bar: bool = None,
     verbose: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     """Generates a list of keyphrases for each cluster in a cluster layer.
 
@@ -610,12 +592,11 @@ def information_weighted_keyphrases(
     keyphrases List[List[str]]
         A list of lists of keyphrases for each cluster.
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
-        show_progress_bar=show_progress_bar,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        show_progress_bar=show_progress_bar,
+        default_verbose=False
     )
     
     keyphrase_vector_mapping = {
@@ -722,9 +703,8 @@ def central_keyphrases(
     embedding_model: SentenceTransformer,
     n_keyphrases: int = 16,
     diversify_alpha: float = 1.0,
-    verbosity: bool = None,
-    show_progress_bar: bool = None,
     verbose: bool = None,
+    show_progress_bar: bool = None,
 ):
     """
     Generates a list of keyphrases for each cluster in a cluster layer using the central keyphrase method.
@@ -753,12 +733,11 @@ def central_keyphrases(
     keyphrases : List[List[str]]
         A list of lists of keyphrases for each cluster.
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
-        show_progress_bar=show_progress_bar,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        show_progress_bar=show_progress_bar,
+        default_verbose=False
     )
     keyphrase_vector_mapping = {
         keyphrase: vector
@@ -860,9 +839,8 @@ def bm25_keyphrases(
     k1: float = 1.5,
     b: float = 0.75,
     diversify_alpha: float = 1.0,
-    verbosity: bool = None,
-    show_progress_bar: bool = None,
     verbose: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     """Generates a list of keyphrases for each cluster in a cluster layer using BM25 for scoring.
 
@@ -892,12 +870,11 @@ def bm25_keyphrases(
     keyphrases : List[List[str]]
         A list of lists of keyphrases for each cluster.
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
-        show_progress_bar=show_progress_bar,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        show_progress_bar=show_progress_bar,
+        default_verbose=False
     )
     keyphrase_vector_mapping = {
         keyphrase: vector
@@ -1027,9 +1004,8 @@ def submodular_selection_information_keyphrases(
     prior_strength: float = 0.01,
     weight_power: float = 2.0,
     submodular_function: str = "saturated_coverage",
-    verbosity: bool = None,
-    show_progress_bar: bool = None,
     verbose: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     """Generates a list of keyphrases for each cluster in a cluster layer using saturated coverage information.
 
@@ -1062,12 +1038,11 @@ def submodular_selection_information_keyphrases(
     keyphrases : List[List[str]]
         A list of lists of keyphrases for each cluster.
     """
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
-        show_progress_bar=show_progress_bar,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
         verbose=verbose,
-        default_verbosity=False
+        show_progress_bar=show_progress_bar,
+        default_verbose=False
     )
     keyphrase_vector_mapping = {
         keyphrase: vector

--- a/toponymy/prompt_construction.py
+++ b/toponymy/prompt_construction.py
@@ -89,7 +89,7 @@ def cluster_topic_names_for_renaming(
                 "Either topic_name_embeddings or embedding_model must be provided."
             )
         topic_name_embeddings = embedding_model.encode(
-            topic_names, show_progress_bar=True
+            topic_names, verbosity=True
         )
     distances = pairwise_distances(topic_name_embeddings, metric="cosine")
     threshold = find_threshold_for_max_cluster_size(distances)

--- a/toponymy/prompt_construction.py
+++ b/toponymy/prompt_construction.py
@@ -89,7 +89,7 @@ def cluster_topic_names_for_renaming(
                 "Either topic_name_embeddings or embedding_model must be provided."
             )
         topic_name_embeddings = embedding_model.encode(
-            topic_names, verbosity=True
+            topic_names, verbose=True
         )
     distances = pairwise_distances(topic_name_embeddings, metric="cosine")
     threshold = find_threshold_for_max_cluster_size(distances)

--- a/toponymy/subtopics.py
+++ b/toponymy/subtopics.py
@@ -10,7 +10,7 @@ from vectorizers.transformers import InformationWeightTransformer
 
 from toponymy.utility_functions import diversify_max_alpha as diversify
 from toponymy.exemplar_texts import FacilityLocationSelection, SaturatedCoverageSelection
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 from tqdm.auto import tqdm
 
@@ -29,7 +29,7 @@ def central_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     diversify_alpha: float = 1.0,
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
@@ -41,11 +41,11 @@ def central_subtopics(
 
     central_vector = np.mean(subtopic_vectors, axis=0)
 
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     result = []
@@ -112,7 +112,7 @@ def submodular_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     submodular_function: str = "facility_location",
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
@@ -136,11 +136,11 @@ def submodular_subtopics(
             f"selection_function={submodular_function} is not a valid selection. Please choose one of (facility_location,saturated_coverage)"
         )
 
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     result = []
@@ -189,7 +189,7 @@ def central_subtopics_from_all_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     diversify_alpha: float = 1.0,
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
@@ -199,11 +199,11 @@ def central_subtopics_from_all_subtopics(
             )
         subtopic_vectors = subtopic_embeddings(subtopics, embedding_model)
 
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     result = []
@@ -254,7 +254,7 @@ def information_weighted_subtopics(
     n_dictionary_vectors: int = 512,
     coding_transform_alpha: float = 0.1,
     n_jobs=-1,
-    verbosity: bool = None,
+    verbose: bool = None,
     show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
@@ -292,11 +292,11 @@ def information_weighted_subtopics(
     )
     scores = weighted_sparse_coding.sum(axis=1)
 
-    # Handle verbosity parameters
-    show_progress_bar_val, _ = handle_verbosity_params(
-        verbosity=verbosity,
+    # Handle verbose parameters
+    show_progress_bar_val, _ = handle_verbose_params(
+        verbose=verbose,
         show_progress_bar=show_progress_bar,
-        default_verbosity=False
+        default_verbose=False
     )
 
     result = []

--- a/toponymy/subtopics.py
+++ b/toponymy/subtopics.py
@@ -10,6 +10,7 @@ from vectorizers.transformers import InformationWeightTransformer
 
 from toponymy.utility_functions import diversify_max_alpha as diversify
 from toponymy.exemplar_texts import FacilityLocationSelection, SaturatedCoverageSelection
+from toponymy._utils import handle_verbosity_params
 
 from tqdm.auto import tqdm
 
@@ -28,7 +29,8 @@ def central_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     diversify_alpha: float = 1.0,
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
         if embedding_model is None:
@@ -39,11 +41,18 @@ def central_subtopics(
 
     central_vector = np.mean(subtopic_vectors, axis=0)
 
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+
     result = []
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc="Selecting central subtopics",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
         leave=False,
         unit="cluster",
         position=1,
@@ -103,7 +112,8 @@ def submodular_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     submodular_function: str = "facility_location",
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
         if embedding_model is None:
@@ -126,11 +136,18 @@ def submodular_subtopics(
             f"selection_function={submodular_function} is not a valid selection. Please choose one of (facility_location,saturated_coverage)"
         )
 
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+
     result = []
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc=f"Selecting {submodular_function} subtopics",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
         leave=False,
         unit="cluster",
         position=1,
@@ -172,7 +189,8 @@ def central_subtopics_from_all_subtopics(
     embedding_model: Optional[SentenceTransformer] = None,
     n_subtopics: int = 64,
     diversify_alpha: float = 1.0,
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
         if embedding_model is None:
@@ -181,11 +199,18 @@ def central_subtopics_from_all_subtopics(
             )
         subtopic_vectors = subtopic_embeddings(subtopics, embedding_model)
 
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+
     result = []
     for cluster_num in tqdm(
         range(cluster_label_vector.max() + 1),
         desc="Selecting subtopics by topic name",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
     ):
         subtopics_in_cluster = np.unique(
             subtopic_label_vector[cluster_label_vector == cluster_num]
@@ -229,7 +254,8 @@ def information_weighted_subtopics(
     n_dictionary_vectors: int = 512,
     coding_transform_alpha: float = 0.1,
     n_jobs=-1,
-    show_progress_bar: bool = False,
+    verbosity: bool = None,
+    show_progress_bar: bool = None,
 ) -> List[List[str]]:
     if subtopic_vectors is None:
         if embedding_model is None:
@@ -266,11 +292,18 @@ def information_weighted_subtopics(
     )
     scores = weighted_sparse_coding.sum(axis=1)
 
+    # Handle verbosity parameters
+    show_progress_bar_val, _ = handle_verbosity_params(
+        verbosity=verbosity,
+        show_progress_bar=show_progress_bar,
+        default_verbosity=False
+    )
+
     result = []
     for cluster_num in tqdm(
         range(meta_cluster_label_vector.max() + 1),
         desc="Selecting informative subtopics",
-        disable=not show_progress_bar,
+        disable=not show_progress_bar_val,
     ):
         candidate_subtopics = [
             subtopics[x] for x in np.where(meta_cluster_label_vector == cluster_num)[0]

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -3,7 +3,7 @@ from toponymy.keyphrases import KeyphraseBuilder
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from toponymy.topic_tree import TopicTree
 from toponymy.llm_wrappers import LLMWrapper
-from toponymy._utils import handle_verbosity_params
+from toponymy._utils import handle_verbose_params
 
 from sentence_transformers import SentenceTransformer
 from sklearn.utils.validation import check_is_fitted
@@ -40,10 +40,10 @@ class Toponymy:
         The highest detail level to use for the topic names. This should be a value between 0 (finest grained detail) and 1 (very high level).
     exemplar_delimiters: List[str]
         A list of strings that represent the delimiters for the exemplar texts. Default is ["    *\"", "\"\n"].
-    verbosity: bool
+    verbose: bool
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
     show_progress_bars: bool, deprecated
-        Deprecated. Use verbosity instead.
+        Deprecated. Use verbose instead.
 
     Attributes:
     -----------
@@ -67,7 +67,7 @@ class Toponymy:
         The highest detail level to use for the topic names. This should be a value between 0 (finest grained detail) and 1 (very high level).
     exemplar_delimiters: List[str]
         A list of strings that represent the delimiters for the exemplar texts.
-    verbosity: bool
+    verbose: bool
         Whether to show progress bars and verbose output.
     clusterable_vectors_: np.array
         A numpy array of shape=(number_of_objects, clustering_dimension) used for clustering.
@@ -103,7 +103,7 @@ class Toponymy:
         lowest_detail_level: float = 0.0,
         highest_detail_level: float = 1.0,
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
-        verbosity: bool = None,
+        verbose: bool = None,
         show_progress_bars: bool = None,
     ):
         self.llm_wrapper = llm_wrapper
@@ -117,13 +117,12 @@ class Toponymy:
         self.highest_detail_level = highest_detail_level
         self.exemplar_delimiters = exemplar_delimiters
         
-        # Handle verbosity parameters
-        self.show_progress_bars, self.verbose = handle_verbosity_params(
-            verbosity=verbosity,
+        # Handle verbose parameters
+        self.show_progress_bars, self.verbose = handle_verbose_params(
+            verbose=verbose,
             show_progress_bars=show_progress_bars,
-            default_verbosity=True
+            default_verbose=True
         )
-        self.verbosity = self.show_progress_bars  # Store unified parameter
 
     def fit(
         self,
@@ -173,7 +172,7 @@ class Toponymy:
                 clusterable_vectors,
                 embedding_vectors,
                 self.layer_class,
-                verbosity=self.verbosity,
+                verbose=self.verbose,
                 show_progress_bar=self.show_progress_bars,
                 exemplar_delimiters=self.exemplar_delimiters,
                 prompt_format=(

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -3,6 +3,7 @@ from toponymy.keyphrases import KeyphraseBuilder
 from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 from toponymy.topic_tree import TopicTree
 from toponymy.llm_wrappers import LLMWrapper
+from toponymy._utils import handle_verbosity_params
 
 from sentence_transformers import SentenceTransformer
 from sklearn.utils.validation import check_is_fitted
@@ -39,8 +40,10 @@ class Toponymy:
         The highest detail level to use for the topic names. This should be a value between 0 (finest grained detail) and 1 (very high level).
     exemplar_delimiters: List[str]
         A list of strings that represent the delimiters for the exemplar texts. Default is ["    *\"", "\"\n"].
-    show_progress_bars: bool
-        Whether to show progress bars or not.
+    verbosity: bool
+        Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
+    show_progress_bars: bool, deprecated
+        Deprecated. Use verbosity instead.
 
     Attributes:
     -----------
@@ -64,8 +67,8 @@ class Toponymy:
         The highest detail level to use for the topic names. This should be a value between 0 (finest grained detail) and 1 (very high level).
     exemplar_delimiters: List[str]
         A list of strings that represent the delimiters for the exemplar texts.
-    show_progress_bars: bool
-        Whether to show progress bars or not.
+    verbosity: bool
+        Whether to show progress bars and verbose output.
     clusterable_vectors_: np.array
         A numpy array of shape=(number_of_objects, clustering_dimension) used for clustering.
     embedding_vectors_: np.array
@@ -100,7 +103,8 @@ class Toponymy:
         lowest_detail_level: float = 0.0,
         highest_detail_level: float = 1.0,
         exemplar_delimiters: List[str] = ['    * "', '"\n'],
-        show_progress_bars: bool = True,
+        verbosity: bool = None,
+        show_progress_bars: bool = None,
     ):
         self.llm_wrapper = llm_wrapper
         self.embedding_model = text_embedding_model
@@ -112,7 +116,14 @@ class Toponymy:
         self.lowest_detail_level = lowest_detail_level
         self.highest_detail_level = highest_detail_level
         self.exemplar_delimiters = exemplar_delimiters
-        self.show_progress_bars = show_progress_bars
+        
+        # Handle verbosity parameters
+        self.show_progress_bars, self.verbose = handle_verbosity_params(
+            verbosity=verbosity,
+            show_progress_bars=show_progress_bars,
+            default_verbosity=True
+        )
+        self.verbosity = self.show_progress_bars  # Store unified parameter
 
     def fit(
         self,

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -173,6 +173,7 @@ class Toponymy:
                 clusterable_vectors,
                 embedding_vectors,
                 self.layer_class,
+                verbosity=self.verbosity,
                 show_progress_bar=self.show_progress_bars,
                 exemplar_delimiters=self.exemplar_delimiters,
                 prompt_format=(


### PR DESCRIPTION
# Combine verbose and show_progress_bar options into unified verbosity parameter

Fixes #53

## Summary

This PR addresses the user feedback in issue #53 by combining the `verbose` and `show_progress_bar` parameters into a single, more intuitive `verbosity` parameter. This simplification aligns with standard library conventions where enabling verbose mode also enables progress indicators.

## Changes

### New API
- **Single `verbosity` parameter**: 
  - `verbosity=True`: Shows all progress bars and verbose messages
  - `verbosity=False`: Suppresses all output

### Implementation Details

1. **Created utility module** (`toponymy/_utils.py`):
   - `handle_verbosity_params()` function manages parameter precedence and deprecation warnings
   - Ensures backward compatibility while guiding users to the new API

2. **Updated all modules** to support the new parameter:
   - `toponymy.py`: Replaced `show_progress_bars` with `verbosity`
   - `clustering.py`: Updated all clusterer classes and fixed "Layer X found Y clusters" output
   - `keyphrases.py`: Updated all keyphrase extraction functions
   - `subtopics.py`: Updated all subtopic generation functions
   - `exemplar_texts.py`: Updated all exemplar selection functions
   - `embedding_wrappers.py`: Updated all embedder classes
   - `cluster_layer.py`: Updated ClusterLayer classes
   - `prompt_construction.py`: Updated embedding calls

3. **Parameter precedence**:
   - New `verbosity` parameter takes precedence over legacy parameters
   - If multiple parameters are provided: `verbosity` > `verbose` > `show_progress_bar`

4. **Updated documentation**:
   - Added new section in README explaining the verbosity parameter
   - Updated examples to use the new parameter

## Backward Compatibility

All existing code continues to work without modification:
- Legacy parameters (`verbose`, `show_progress_bar`, `show_progress_bars`) are still accepted
- Deprecation warnings guide users to adopt the new API
- Warning message: "Parameters verbose, show_progress_bar are deprecated and will be removed in v2.0. Use 'verbosity' parameter instead."

## Migration Guide

### Before:
```python
# Had to set both parameters for full output
clusterer = ToponymyClusterer(verbose=True, show_progress_bar=True)
toponymy = Toponymy(llm_wrapper=llm, show_progress_bars=True)
```

### After:
```python
# Single parameter controls everything
clusterer = ToponymyClusterer(verbosity=True)
toponymy = Toponymy(llm_wrapper=llm, verbosity=True)
```

## Testing

The changes have been tested with:
- Backward compatibility scenarios (old parameters still work)
- Parameter precedence (new parameter overrides old ones)
- Output verification (progress bars and messages appear correctly)
- Integration testing with the full Toponymy pipeline

## Example Usage

```python
from toponymy import Toponymy, ToponymyClusterer

# Enable all output
clusterer = ToponymyClusterer(min_clusters=4, verbosity=True)
# Shows: "Layer 0 found 142 clusters", progress bars, etc.

# Suppress all output
clusterer = ToponymyClusterer(min_clusters=4, verbosity=False)
# Silent operation

# Backward compatible (shows deprecation warning)
clusterer = ToponymyClusterer(min_clusters=4, verbose=True)
```

## Benefits

1. **Improved user experience**: Single parameter is more intuitive
2. **Consistency**: Aligns with standard library conventions
3. **Simplified API**: Reduces confusion about which parameters to use
4. **Future-proof**: Clean migration path for existing users

This change makes the library more approachable for new users while maintaining compatibility for existing codebases.


<img width="634" height="824" alt="image" src="https://github.com/user-attachments/assets/204e62ba-ee56-433b-b446-8b8a33cbe44e" />
<img width="1096" height="493" alt="image" src="https://github.com/user-attachments/assets/928bb649-8d80-4c2e-ad87-293de5e7e155" />
<img width="1429" height="1201" alt="image" src="https://github.com/user-attachments/assets/4f45aa6e-b70d-41eb-96dd-1c7b0590c08e" />
