### PR TITLE
Add fallback for when new topic names list is empty

### DIFF
--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -247,7 +247,8 @@ class ClusterLayer(ABC):
         Update the topic names for the specified indices.
         """
         for i, topic_index in enumerate(topic_indices):
-            self.topic_names[topic_index] = new_topic_names[i]
+            try: self.topic_names[topic_index] = new_topic_names[i]
+            except IndexError: continue
 
     def _disambiguate_topic_names(self, llm) -> None:  # pragma: no cover
         if isinstance(llm, LLMWrapper):


### PR DESCRIPTION
Toponymy sometimes passes an empty list for new_topic_names to the _update_topic_names function. Indexing this list breaks it, so adding a try/except block will keep the old topic names and run without errors.

Note: if _update_topic_names is called, but new_topic_names does not contain any elements, there may be an issue upstream with the creation of new_topic_names. This PR may be fixing a symptom, not the root problem. 