### PR TITLE
Replace deprecated show_progress_bars with verbose in tests

### DIFF
--- a/toponymy/tests/test_topic_tree.py
+++ b/toponymy/tests/test_topic_tree.py
@@ -781,7 +781,7 @@ def test_unfitted_toponymy_fails(null_llm, embedder, clusterer):
         corpus_description = "collection of sentences",
         lowest_detail_level = 0.8,
         highest_detail_level = 1.0,
-        show_progress_bars=True,
+        verbose=True,
     )
     with pytest.raises(NotFittedError, match="This Toponymy instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator."):
         model.topic_tree_

--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -39,7 +39,7 @@ def test_toponymy(
         corpus_description="collection of sentences",
         lowest_detail_level=0.8,
         highest_detail_level=1.0,
-        show_progress_bars=True,
+        verbose=True,
     )
     model.fit(all_sentences, object_vectors, clusterable_vectors)
     embedded_topic_names = embedder.encode(model.topic_names_[1])
@@ -85,7 +85,7 @@ def test_toponymy_alternative_options(
         corpus_description="collection of sentences",
         lowest_detail_level=0.8,
         highest_detail_level=1.0,
-        show_progress_bars=True,
+        verbose=True,
     )
     topic_name_vectors = model.fit_predict(
         all_sentences,
@@ -137,7 +137,7 @@ def test_toponymy_alternative_options_2(
         corpus_description="collection of sentences",
         lowest_detail_level=0.8,
         highest_detail_level=1.0,
-        show_progress_bars=True,
+        verbose=True,
     )
     topic_name_vectors = model.fit_predict(
         all_sentences,
@@ -310,7 +310,7 @@ def test_toponymy_with_ollama(
                     corpus_description="collection of sentences",
                     lowest_detail_level=0.8,
                     highest_detail_level=1.0,
-                    show_progress_bars=True,
+                    verbose=True,
                 )
 
                 model.fit(all_sentences, object_vectors, clusterable_vectors)
@@ -505,7 +505,7 @@ def test_toponymy_async_ollama(
                     corpus_description="collection of sentences",
                     lowest_detail_level=0.8,
                     highest_detail_level=1.0,
-                    show_progress_bars=True,
+                    verbose=True,
                 )
 
                 topic_name_vectors = model.fit_predict(
@@ -839,7 +839,7 @@ def test_toponymy_with_mocked_ollama(
             corpus_description="collection of sentences",
             lowest_detail_level=0.8,
             highest_detail_level=1.0,
-            show_progress_bars=True,
+            verbose=True,
         )
 
         model.fit(all_sentences, object_vectors, clusterable_vectors)


### PR DESCRIPTION
Since we are deprecating show_progress_bars in future releases we should probably practice what we preach and swap it for verbose in our unit tests.