### PR TITLE
Add callbacks

### DIFF
--- a/toponymy/debug_logging.py
+++ b/toponymy/debug_logging.py
@@ -1,0 +1,85 @@
+import json
+from pathlib import Path
+from typing import Any
+
+
+class BasicDebugLogger:
+    """
+    Synchronous JSONL logger for LLM wrapper callbacks. Appends one JSON record
+    per event to *path*, optionally truncating long ``prompt`` and
+    ``raw_response`` fields so logs stay readable during development.
+
+    Not suitable for high-volume runs — each event blocks on a file open/write.
+    For production use, swap in a buffered or queue-backed callback instead.
+
+    Args:
+        path: Destination file. Appends to an existing file.
+        truncate: If True, long string values in ``prompt`` and
+                  ``raw_response`` are trimmed to *max_len* characters.
+        max_len: Maximum characters kept per field when truncating
+                 (half from the start, half from the end).
+    """
+
+    def __init__(
+        self,
+        path: str | Path = "llm_debug.jsonl",
+        *,
+        truncate: bool = True,
+        max_len: int = 2000,
+    ):
+        self.path = Path(path)
+        self.truncate = truncate
+        self.max_len = max_len
+
+    def _truncate(self, value: Any) -> Any:
+        if not self.truncate or not isinstance(value, str):
+            return value
+
+        if len(value) <= self.max_len:
+            return value
+
+        half = self.max_len // 2
+        return value[:half] + "\n...[truncated]...\n" + value[-half:]
+
+    def _process(self, event: dict[str, Any]) -> dict[str, Any]:
+        processed = {}
+
+        for key, value in event.items():
+            if key in {"prompt", "raw_response"}:
+                if isinstance(value, dict):
+                    processed[key] = {
+                        subkey: self._truncate(subvalue)
+                        for subkey, subvalue in value.items()
+                    }
+                else:
+                    processed[key] = self._truncate(value)
+            else:
+                processed[key] = value
+
+        return processed
+
+    def __call__(self, event: dict[str, Any]) -> None:
+        try:
+            processed = self._process(event)
+            line = json.dumps(processed, ensure_ascii=False)
+        except Exception as e:
+            line = json.dumps(
+                {
+                    "logger_error": "failed to process/serialize event",
+                    "error": {
+                        "type": type(e).__name__,
+                        "message": str(e),
+                    },
+                },
+                ensure_ascii=False,
+            )
+
+        try:
+            with self.path.open("a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except Exception as e:
+            warnings.warn(
+                f"{self.__class__.__name__} could not write to {self.path}: {e}",
+                UserWarning,
+                stacklevel=2,
+            )

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -10,7 +10,7 @@ from toponymy.templates import (
     default_extract_topic_names,
 )
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union, Dict, Generic, TypeVar, Any
+from typing import List, Optional, Union, Dict, Generic, TypeVar, Callable, Any
 from tenacity import retry, stop_after_attempt, retry_if_exception, AsyncRetrying, wait_random_exponential
 from dataclasses import dataclass
 
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 T = TypeVar("T")
+DebugCallback = Callable[[dict[str, Any]], None]
+
 
 # Ignore internal litellm warning
 filterwarnings(
@@ -154,6 +156,53 @@ class LLMErrorHandlingMixin:
             f"override _raise_fail_fast_from_batch_error: {error}"
         )
 
+
+class DebugCallbackMixin:
+    """
+    Mixin providing optional debug callback support for LLM wrappers.
+
+    This mixin allows wrappers to emit structured debug events (e.g., prompts,
+    raw LLM responses, errors, and metadata) to a user-supplied callback
+    function. The callback is intended for debugging, logging, or observability
+    purposes such as inspecting prompts/responses or recording them to a file.
+
+    Wrappers opt into emitting events by setting `_supports_debug_callback = True`.
+
+    The helper `_warn_if_debug_callback_unsupported` provides a check to warn if
+    a debug callback is provided but not supported.
+    """
+    _supports_debug_callback: bool = False
+    callback: DebugCallback | None = None
+
+    def _emit_debug_callback(self, payload: dict[str, Any]) -> None:
+        callback = getattr(self, "callback", None)
+        if callback is None:
+            return
+
+        try:
+            callback(
+                {
+                    "wrapper": self.__class__.__name__,
+                    "model": getattr(self, "model", None),
+                    **payload,
+                }
+            )
+        except Exception:
+            pass
+
+    def _warn_if_debug_callback_unsupported(self) -> None:
+        callback = getattr(self, "callback", None)
+
+        if callback is not None and not self._supports_debug_callback:
+            warn(
+                (
+                    f"{self.__class__.__name__} received a debug callback, but "
+                    "this wrapper does not currently support debug callback events."
+                ),
+                UserWarning,
+                stacklevel=2,
+            )
+
 def repair_json_string_backslashes(s: str) -> str:
     """
     Attempts to repair a string that should be JSON by escaping unescaped backslashes.
@@ -200,7 +249,7 @@ def llm_output_to_result(llm_output: str, regex: str) -> dict:
     return result
 
 
-class LLMWrapper(LLMErrorHandlingMixin, ABC):
+class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     FAIL_FAST_EXCEPTIONS: tuple = ()
 
     @abstractmethod
@@ -445,7 +494,7 @@ class LLMWrapper(LLMErrorHandlingMixin, ABC):
 
         return result
 
-class AsyncLLMWrapper(LLMErrorHandlingMixin, ABC):
+class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_single_llm(
         self, prompt: str, temperature: float, max_tokens: int
@@ -997,13 +1046,15 @@ try:
             Indicates whether the wrapper supports system prompts. For LlamaCpp, this is always False.
         """
 
-        def __init__(self, model_path: str, llm_specific_instructions=None, **kwargs):
+        def __init__(self, model_path: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
             self.model_path = model_path
             for arg, val in kwargs.items():
                 if arg == "n_ctx":
                     continue
                 setattr(self, arg, val)
             self.llm = llama_cpp.Llama(model_path=model_path, **kwargs)
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -1079,8 +1130,10 @@ try:
             Indicates whether the wrapper supports system prompts. For Huggingface, this is always True.
         """
 
-        def __init__(self, model: str, llm_specific_instructions=None, **kwargs):
+        def __init__(self, model: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.llm = transformers.pipeline("text-generation", model=model, **kwargs)
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
@@ -1128,9 +1181,12 @@ try:
             model: str,
             llm_specific_instructions: Optional[str] = None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
             **kwargs,
         ):
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.llm = transformers.pipeline("text-generation", model=model, **kwargs)
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
@@ -1228,8 +1284,10 @@ try:
             Indicates whether the wrapper supports system prompts. For Huggingface, this is always True.
         """
 
-        def __init__(self, model: str, llm_specific_instructions=None, **kwargs):
+        def __init__(self, model: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.kwargs = kwargs
             self._start_engine()
             self.extra_prompting = (
@@ -1288,9 +1346,12 @@ try:
             model: str,
             llm_specific_instructions: Optional[str] = None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
             **kwargs,
         ):
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.kwargs = kwargs
             self._start_engine()
             self.extra_prompting = (
@@ -1428,6 +1489,7 @@ try:
             base_url: str = None,
             httpx_client: Optional[httpx.Client] = None,
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             if base_url is None:
                 base_url = os.getenv("CO_API_URL", "https://api.cohere.com")
@@ -1449,6 +1511,8 @@ try:
                 msg = f"Model '{model}' not found, try one of {models}"
                 raise ValueError(msg)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -1545,6 +1609,7 @@ try:
             max_concurrent_requests: int = 10,
             base_url: str = None,
             httpx_client: Optional[httpx.Client] = None,
+            callback: DebugCallback | None = None,
         ):
             if base_url is None:
                 base_url = os.getenv("CO_API_URL", "https://api.cohere.com")
@@ -1559,6 +1624,8 @@ try:
                 api_key=api_key, base_url=base_url, httpx_client=httpx_client
             )
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -1700,9 +1767,12 @@ try:
             llm_specific_instructions=None,
             polling_interval: int = 60,
             timeout: int = 7200,
+            callback: DebugCallback | None = None,
         ):
             self.client = cohere.ClientV2(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -1971,6 +2041,7 @@ try:
             api_key: str,
             model: str = "claude-haiku-4-5-20251001",
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
             if not api_key:
@@ -1980,6 +2051,8 @@ try:
 
             self.llm = anthropic.Anthropic(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2064,6 +2137,7 @@ try:
             model: str = "claude-haiku-4-5-20251001",
             llm_specific_instructions=None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
         ):
 
             api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
@@ -2074,6 +2148,8 @@ try:
 
             self.client = anthropic.AsyncAnthropic(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2174,9 +2250,12 @@ try:
             llm_specific_instructions=None,
             polling_interval: int = 60,
             timeout: int = 7200,
+            callback: DebugCallback | None = None,
         ):
             self.client = anthropic.Anthropic(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2444,6 +2523,7 @@ try:
         consider using the AsyncOpenAI wrapper instead.
         """
         FAIL_FAST_EXCEPTIONS = (AuthenticationError, PermissionDeniedError, BadRequestError, NotFoundError, UnprocessableEntityError)
+        _supports_debug_callback = True
 
         def __init__(
             self,
@@ -2452,6 +2532,7 @@ try:
             base_url: str = None,
             http_client: "httpx.Client | None" = None,
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("OPENAI_API_KEY")
             if not api_key:
@@ -2463,6 +2544,8 @@ try:
                 api_key=api_key, base_url=base_url, http_client=http_client
             )
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2551,6 +2634,7 @@ try:
             Indicates whether the wrapper supports system prompts. For OpenAI, this is always True.
         """
         FAIL_FAST_EXCEPTIONS = (AuthenticationError, PermissionDeniedError, BadRequestError, NotFoundError, UnprocessableEntityError)
+        _supports_debug_callback = True
 
         def __init__(
             self,
@@ -2560,6 +2644,7 @@ try:
             max_concurrent_requests: int = 10,
             organization: str = None,
             base_url: str = None,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("OPENAI_API_KEY")
             if not api_key:
@@ -2569,6 +2654,8 @@ try:
 
             self.client = openai.AsyncOpenAI(api_key=api_key, organization=organization)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2674,6 +2761,7 @@ try:
             api_key: str,
             model: str = "meta-llama/Llama-3-8b-chat-hf",
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("TOGETHER_API_KEY")
             if not api_key:
@@ -2683,6 +2771,8 @@ try:
 
             self.client = together.Together(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2756,6 +2846,7 @@ try:
             model: str = "meta-llama/Llama-3-8b-chat-hf",
             llm_specific_instructions=None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("TOGETHER_API_KEY")
             if not api_key:
@@ -2765,6 +2856,8 @@ try:
 
             self.client = together.AsyncTogether(api_key=api_key)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -2899,6 +2992,7 @@ try:
             api_token: str = None,
             model: str = "meta/llama-2-70b-chat",
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             api_token = api_token or os.getenv("REPLICATE_API_TOKEN")
             if not api_token:
@@ -2908,6 +3002,8 @@ try:
 
             os.environ["REPLICATE_API_TOKEN"] = api_token
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -3009,10 +3105,12 @@ try:
             endpoint: str,
             model: str,
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             self.endpoint = endpoint
             self.model = model
-
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             api_key = api_key or os.getenv("AZURE_API_KEY")
             if not api_key:
                 raise ValueError(
@@ -3120,6 +3218,7 @@ try:
             model: str,
             llm_specific_instructions=None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("AZURE_API_KEY")
             if not api_key:
@@ -3136,7 +3235,8 @@ try:
                 raise ValueError(
                     "Azure model name is required. Provide the name of the Azure AI Foundry model to use."
                 )
-
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.endpoint = endpoint
             self.model = model
             self.client = AsyncChatCompletionsClient(
@@ -3282,6 +3382,7 @@ try:
             llm_specific_instructions=None,
             polling_interval: int = 60,
             timeout: int = 7200,
+            callback: DebugCallback | None = None,
         ):
             self.client = anthropic.Anthropic(api_key=api_key)
             self.model = model
@@ -3290,6 +3391,8 @@ try:
             )
             self.polling_interval = polling_interval
             self.timeout = timeout
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
 
         async def _call_llm_batch(
             self, prompts: List[str], temperature: float, max_tokens: int
@@ -3535,9 +3638,12 @@ try:
             model: str = "llama3.2",
             host: str = "http://localhost:11434",
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             self.client = ollama.Client(host=host)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -3616,9 +3722,12 @@ try:
             host: str = "http://localhost:11434",
             llm_specific_instructions=None,
             max_concurrent_requests: int = 5,
+            callback: DebugCallback | None = None,
         ):
             self.client = ollama.AsyncClient(host=host)
             self.model = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -3755,6 +3864,7 @@ try:
             api_key: str,
             model: str = "gemini-1.5-flash",
             llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("GOOGLE_API_KEY")
             if not api_key:
@@ -3764,6 +3874,8 @@ try:
 
             genai.configure(api_key=api_key)
             self.model = genai.GenerativeModel(model)
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.model_name = model
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
@@ -3844,6 +3956,7 @@ try:
             model: str = "gemini-1.5-flash",
             llm_specific_instructions=None,
             max_concurrent_requests: int = 10,
+            callback: DebugCallback | None = None,
         ):
             api_key = api_key or os.getenv("GOOGLE_API_KEY")
             if not api_key:
@@ -3854,6 +3967,8 @@ try:
             genai.configure(api_key=api_key)
             self.model = genai.GenerativeModel(model)
             self.model_name = model
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -4013,6 +4128,7 @@ try:
             NotFoundError,
             UnprocessableEntityError,
         )
+        _supports_debug_callback = True
 
         def __init__(
             self,
@@ -4023,11 +4139,14 @@ try:
             use_json_object: bool = None,
             disable_system_prompts: bool = False,
             completion_kwargs: dict[str, Any] | None = None,
+            callback: DebugCallback | None = None,
         ):
 
             self.api_key = api_key
             self.model = model
             self.api_base = api_base
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
@@ -4265,7 +4384,7 @@ try:
             NotFoundError,
             UnprocessableEntityError,
         )
-
+        _supports_debug_callback = True
         def __init__(
             self,
             api_key: str = None,
@@ -4276,11 +4395,14 @@ try:
             use_json_object:  bool | None = None,
             disable_system_prompts:  bool = False,
             completion_kwargs: dict[str, Any] | None = None,
+            callback: DebugCallback | None = None,
         ):
 
             self.api_key = api_key
             self.model = model
             self.api_base = api_base
+            self.callback = callback
+            self._warn_if_debug_callback_unsupported()
             self.extra_prompting = (
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -108,6 +108,8 @@ class LLMErrorHandlingMixin:
         *args,
         **kwargs,
     ) -> CallResult:
+        prompt = kwargs.get("prompt")
+        routine = kwargs.pop("routine", None)
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(3),
@@ -117,6 +119,15 @@ class LLMErrorHandlingMixin:
             ):
                 with attempt:
                     value = await fn(*args, **kwargs)
+                    # SUCCESS emit
+                    self._emit_debug_callback(
+                        {
+                            "event": "llm_call_success",
+                            "routine": routine,
+                            "prompt": prompt,
+                            "raw_response": value,
+                        }
+                    )
                     return CallResult(value=value)
         except Exception as e:
             if isinstance(e, (InvalidLLMInputError, *self.FAIL_FAST_EXCEPTIONS)):
@@ -128,6 +139,18 @@ class LLMErrorHandlingMixin:
                 self.__class__.__name__,
                 type(e).__name__,
                 str(e)[:200],
+            )
+            # ERROR emit
+            self._emit_debug_callback(
+                {
+                    "event": "llm_call_error",
+                    "routine": routine,
+                    "prompt": prompt,
+                    "error": {
+                        "type": type(e).__name__,
+                        "message": str(e),
+                    },
+                }
             )
             return CallResult(error=e)
 
@@ -270,20 +293,83 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         """
         pass
 
-    def _safe_call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+    def _safe_call_llm(
+            self,
+            prompt: str,
+            temperature: float,
+            max_tokens: int,
+            routine: str | None = None
+        ) -> str:
         try:
-            return self._call_llm(prompt, temperature, max_tokens)
+            raw_response = self._call_llm(prompt, temperature, max_tokens)
+
+            self._emit_debug_callback(
+                {
+                    "event": "llm_call_success",
+                    "prompt_type": "single",
+                    "routine": routine,
+                    "prompt": prompt,
+                    "raw_response": raw_response,
+                }
+            )
+            return raw_response
+
         except Exception as e:
+            self._emit_debug_callback(
+                {
+                    "event": "llm_call_error",
+                    "prompt_type": "single",
+                    "routine": routine,
+                    "prompt": prompt,
+                    "error": {
+                        "type": type(e).__name__,
+                        "message": str(e),
+                    },
+                }
+            )
             self._handle_exception(e)
 
     def _safe_call_llm_with_system_prompt(
-        self, system_prompt: str, user_prompt: str, temperature: float, max_tokens: int
+        self, system_prompt: str,
+        user_prompt: str,
+        temperature: float,
+        max_tokens: int,
+        routine: str | None = None
     ) -> str:
+        prompt_payload = {
+            "system": system_prompt,
+            "user": user_prompt,
+        }
+
         try:
-            return self._call_llm_with_system_prompt(
+            raw_response = self._call_llm_with_system_prompt(
                 system_prompt, user_prompt, temperature, max_tokens
             )
+
+            self._emit_debug_callback(
+                {
+                    "event": "llm_call_success",
+                    "prompt_type": "system",
+                    "routine": routine,
+                    "prompt": prompt_payload,
+                    "raw_response": raw_response,
+                }
+            )
+            return raw_response
+
         except Exception as e:
+            self._emit_debug_callback(
+                {
+                    "event": "llm_call_error",
+                    "prompt_type": "system",
+                    "routine": routine,
+                    "prompt": prompt_payload,
+                    "error": {
+                        "type": type(e).__name__,
+                        "message": str(e),
+                    },
+                }
+            )
             self._handle_exception(e)
 
     @staticmethod
@@ -311,7 +397,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     ) -> str:
         if isinstance(prompt, str):
             topic_name_info_raw = self._safe_call_llm(
-                prompt, temperature, max_tokens=128
+                prompt, temperature, max_tokens=128, routine="generate_topic_names",
             )
         elif isinstance(prompt, dict) and self.supports_system_prompts:
             topic_name_info_raw = self._safe_call_llm_with_system_prompt(
@@ -319,6 +405,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 user_prompt=prompt["user"],
                 temperature=temperature,
                 max_tokens=128,
+                routine="generate_topic_names",
             )
         else:
             raise InvalidLLMInputError(
@@ -365,7 +452,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
         if isinstance(prompt, str):
             topic_name_info_raw = self._safe_call_llm(
-                prompt, temperature, max_tokens=1024
+                prompt, temperature, max_tokens=1024, routine="generate_topic_cluster_names",
             )
         elif isinstance(prompt, dict) and self.supports_system_prompts:
             topic_name_info_raw = self._safe_call_llm_with_system_prompt(
@@ -373,6 +460,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 user_prompt=prompt["user"],
                 temperature=temperature,
                 max_tokens=1024,
+                routine="generate_topic_cluster_names",
             )
         else:
             raise InvalidLLMInputError(
@@ -568,7 +656,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         )
 
     async def _call_llm_batch(
-        self, prompts: List[str], temperature: float, max_tokens: int
+        self, prompts: List[str], temperature: float, max_tokens: int, routine: str | None = None
     ) -> List[CallResult[str]]:
         """
         Process a batch of prompts and return one CallResult per prompt.
@@ -612,6 +700,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 prompt,
                 temperature,
                 max_tokens,
+                routine=routine,
             )
             for prompt in prompts
         ]
@@ -623,6 +712,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         user_prompts: List[str],
         temperature: float,
         max_tokens: int,
+        routine: str | None = None,
     ) -> List[CallResult[str]]:
         """
         Process a batch of system prompt + user prompt pairs and return one CallResult
@@ -673,6 +763,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 user_prompt,
                 temperature,
                 max_tokens,
+                routine=routine,
             )
             for sys_prompt, user_prompt in zip(system_prompts, user_prompts)
         ]

--- a/toponymy/tests/helpers/llm_test_config.py
+++ b/toponymy/tests/helpers/llm_test_config.py
@@ -2,6 +2,7 @@ import json
 from typing import List
 import os
 import pytest
+from toponymy.llm_wrappers import AnthropicNamer, AsyncAnthropicNamer, AsyncAzureAINamer, AsyncCohereNamer, AsyncGoogleGeminiNamer, AsyncHuggingFaceNamer, AsyncLiteLLMNamer, AsyncOllamaNamer, AsyncOpenAINamer, AsyncTogether, AsyncVLLMNamer, AzureAINamer, BatchAnthropicNamer, BatchAzureAINamer, CohereBatchNamer, CohereNamer, GoogleGeminiNamer, HuggingFaceNamer, LiteLLMNamer, LlamaCppNamer, OllamaNamer, OpenAINamer, ReplicateNamer, TogetherNamer, VLLMNamer,, AsyncOpenAINamer AsyncLiteLLMNamer, GoogleGeminiNamer, HuggingFaceNamer, LiteLLMNamer, LlamaCppNamer, OpenAINamer
 
 
 # Mock responses for different scenarios
@@ -72,4 +73,40 @@ LITELLM_PROVIDER_CASES = [
         },
         id="anthropic",
     ),
+]
+
+SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS = [
+    (OpenAINamer, {"api_key": "dummy"}),
+    (LiteLLMNamer, {}),
+]
+UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS =[
+    (LlamaCppNamer, {}),
+    (HuggingFaceNamer, {}),
+    (VLLMNamer, {}),
+    (CohereNamer, {}),
+    (AnthropicNamer, {}),
+    (TogetherNamer, {}),
+    (ReplicateNamer, {}),
+    (AzureAINamer, {}),
+    (OllamaNamer, {}),
+    (GoogleGeminiNamer, {}),
+]
+
+SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS = [
+    (AsyncOpenAINamer, {"api_key": "dummy"}),
+    (AsyncLiteLLMNamer, {}),
+]
+UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS =[
+    (AsyncHuggingFaceNamer, {}),
+    (AsyncVLLMNamer, {}),
+    (AsyncCohereNamer, {}),
+    (CohereBatchNamer, {}),
+    (AsyncAnthropicNamer, {}),
+    (BatchAnthropicNamer, {}),
+    (AsyncOpenAINamer, {}),
+    (AsyncTogether, {}),
+    (AsyncAzureAINamer, {}),
+    (BatchAzureAINamer, {}),
+    (AsyncOllamaNamer, {}),
+    (AsyncGoogleGeminiNamer, {}),
 ]

--- a/toponymy/tests/helpers/llm_test_config.py
+++ b/toponymy/tests/helpers/llm_test_config.py
@@ -2,8 +2,40 @@ import json
 from typing import List
 import os
 import pytest
-from toponymy.llm_wrappers import AnthropicNamer, AsyncAnthropicNamer, AsyncAzureAINamer, AsyncCohereNamer, AsyncGoogleGeminiNamer, AsyncHuggingFaceNamer, AsyncLiteLLMNamer, AsyncOllamaNamer, AsyncOpenAINamer, AsyncTogether, AsyncVLLMNamer, AzureAINamer, BatchAnthropicNamer, BatchAzureAINamer, CohereBatchNamer, CohereNamer, GoogleGeminiNamer, HuggingFaceNamer, LiteLLMNamer, LlamaCppNamer, OllamaNamer, OpenAINamer, ReplicateNamer, TogetherNamer, VLLMNamer,, AsyncOpenAINamer AsyncLiteLLMNamer, GoogleGeminiNamer, HuggingFaceNamer, LiteLLMNamer, LlamaCppNamer, OpenAINamer
-
+from toponymy.llm_wrappers import (
+    AnthropicNamer,
+    AsyncAnthropicNamer,
+    AsyncAzureAINamer,
+    AsyncCohereNamer,
+    AsyncGoogleGeminiNamer,
+    AsyncHuggingFaceNamer,
+    AsyncLiteLLMNamer,
+    AsyncOllamaNamer,
+    AsyncOpenAINamer,
+    AsyncTogether,
+    AsyncVLLMNamer,
+    AzureAINamer,
+    BatchAnthropicNamer,
+    BatchAzureAINamer,
+    CohereBatchNamer,
+    CohereNamer,
+    GoogleGeminiNamer,
+    HuggingFaceNamer,
+    LiteLLMNamer,
+    LlamaCppNamer,
+    OllamaNamer,
+    OpenAINamer,
+    ReplicateNamer,
+    TogetherNamer,
+    VLLMNamer,
+    AsyncOpenAINamer,
+    AsyncLiteLLMNamer,
+    GoogleGeminiNamer,
+    HuggingFaceNamer,
+    LiteLLMNamer,
+    LlamaCppNamer,
+    OpenAINamer
+)
 
 # Mock responses for different scenarios
 VALID_TOPIC_NAME_RESPONSE = {
@@ -80,33 +112,33 @@ SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS = [
     (LiteLLMNamer, {}),
 ]
 UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS =[
-    (LlamaCppNamer, {}),
-    (HuggingFaceNamer, {}),
-    (VLLMNamer, {}),
-    (CohereNamer, {}),
-    (AnthropicNamer, {}),
-    (TogetherNamer, {}),
-    (ReplicateNamer, {}),
-    (AzureAINamer, {}),
-    (OllamaNamer, {}),
-    (GoogleGeminiNamer, {}),
+    (HuggingFaceNamer, {"model": "hf-internal-testing/tiny-random-gpt2"}),
+    (AnthropicNamer, {"api_key": "dummy"}),
+    (TogetherNamer, {"api_key": "dummy"}),
+    (ReplicateNamer, {"api_token": "dummy"}),
+    (AzureAINamer, {"api_key": "dummy", "endpoint": "dummy", "model": "dummy/model"}),
+    (GoogleGeminiNamer, {"api_key": "dummy"}),
+    # exclude namers needing mocking to get around setup
+    #(OllamaNamer, {}),
+    #(VLLMNamer, {}),
+    #(CohereNamer, {"api_key": "dummy"}),
+    #(LlamaCppNamer, {"model_path": "dummy/path/to/model.gguf"}),
 ]
-
 SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS = [
     (AsyncOpenAINamer, {"api_key": "dummy"}),
     (AsyncLiteLLMNamer, {}),
 ]
 UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS =[
-    (AsyncHuggingFaceNamer, {}),
-    (AsyncVLLMNamer, {}),
-    (AsyncCohereNamer, {}),
-    (CohereBatchNamer, {}),
-    (AsyncAnthropicNamer, {}),
-    (BatchAnthropicNamer, {}),
-    (AsyncOpenAINamer, {}),
-    (AsyncTogether, {}),
-    (AsyncAzureAINamer, {}),
-    (BatchAzureAINamer, {}),
-    (AsyncOllamaNamer, {}),
-    (AsyncGoogleGeminiNamer, {}),
+    (AsyncHuggingFaceNamer, {"model": "hf-internal-testing/tiny-random-gpt2"}),
+    (AsyncCohereNamer, {"api_key": "dummy"}),
+    (CohereBatchNamer, {"api_key": "dummy"}),
+    (AsyncAnthropicNamer, {"api_key": "dummy"}),
+    (BatchAnthropicNamer, {"api_key": "dummy"}),
+    (AsyncTogether, {"api_key": "dummy"}),
+    (AsyncAzureAINamer, {"api_key": "dummy", "endpoint": "dummy", "model": "dummy/model"}),
+    (BatchAzureAINamer, {"api_key": "dummy", "endpoint": "dummy", "model": "dummy/model"}),
+    (AsyncGoogleGeminiNamer, {"api_key": "dummy"}),
+    # exclude namers needing mocking to get around setup
+    #(AsyncVLLMNamer, {}),
+    #(AsyncOllamaNamer, {}),
 ]

--- a/toponymy/tests/test_async_llm_wrappers.py
+++ b/toponymy/tests/test_async_llm_wrappers.py
@@ -91,6 +91,7 @@ class MockAsyncResponse:
 
         return Response(content)
 
+
 # Test callback support in all wrappers
 @pytest.mark.parametrize("namer_cls, kwargs", SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS)
 def test_supported_async_namers_do_not_warn_on_callback(namer_cls, kwargs):
@@ -100,13 +101,11 @@ def test_supported_async_namers_do_not_warn_on_callback(namer_cls, kwargs):
         warnings.simplefilter("always")
         namer_cls(callback=callback, **kwargs)
 
-    debug_warnings = [
-        w for w in record
-        if "debug callback" in str(w.message)
-    ]
+    debug_warnings = [w for w in record if "debug callback" in str(w.message)]
 
     assert len(debug_warnings) == 0
     assert namer_cls._supports_debug_callback is True
+
 
 @pytest.mark.parametrize("namer_cls, kwargs", UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS)
 def test_unsupported_async_namers_warn_on_callback(namer_cls, kwargs):
@@ -116,6 +115,7 @@ def test_unsupported_async_namers_warn_on_callback(namer_cls, kwargs):
         namer_cls(callback=callback, **kwargs)
     assert namer_cls._supports_debug_callback is False
 
+
 @pytest.mark.parametrize(
     "namer_cls, kwargs",
     SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS + UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS,
@@ -124,11 +124,9 @@ def test_async_no_warning_when_no_callback(namer_cls, kwargs):
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         namer_cls(callback=None, **kwargs)
-    debug_warnings = [
-        w for w in record
-        if "debug callback" in str(w.message)
-    ]
+    debug_warnings = [w for w in record if "debug callback" in str(w.message)]
     assert len(debug_warnings) == 0
+
 
 # AsyncCohere Tests
 @pytest_asyncio.fixture

--- a/toponymy/tests/test_async_llm_wrappers.py
+++ b/toponymy/tests/test_async_llm_wrappers.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
@@ -12,7 +13,9 @@ from toponymy.llm_wrappers import (
 from toponymy.tests.helpers.llm_test_config import (
     validate_topic_name,
     validate_cluster_names,
-    LITELLM_PROVIDER_CASES
+    LITELLM_PROVIDER_CASES,
+    SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS,
+    UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS,
 )
 from toponymy.tests.helpers.errors import (
     ANTHROPIC_FAIL_FAST,
@@ -78,6 +81,44 @@ class MockAsyncResponse:
 
         return Response(content)
 
+# Test callback support in all wrappers
+@pytest.mark.parametrize("namer_cls, kwargs", SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS)
+def test_supported_async_namers_do_not_warn_on_callback(namer_cls, kwargs):
+    callback = lambda payload: None
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        namer_cls(callback=callback, **kwargs)
+
+    debug_warnings = [
+        w for w in record
+        if "debug callback" in str(w.message)
+    ]
+
+    assert len(debug_warnings) == 0
+    assert namer_cls._supports_debug_callback is True
+
+@pytest.mark.parametrize("namer_cls, kwargs", UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS)
+def test_unsupported_async_namers_warn_on_callback(namer_cls, kwargs):
+    callback = lambda payload: None
+
+    with pytest.warns(UserWarning, match="debug callback") as record:
+        namer_cls(callback=callback, **kwargs)
+    assert namer_cls._supports_debug_callback is False
+
+@pytest.mark.parametrize(
+    "namer_cls, kwargs",
+    SUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS + UNSUPPORTED_ASYNC_DEBUG_CALLBACK_NAMERS,
+)
+def test_async_no_warning_when_no_callback(namer_cls, kwargs):
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        namer_cls(callback=None, **kwargs)
+    debug_warnings = [
+        w for w in record
+        if "debug callback" in str(w.message)
+    ]
+    assert len(debug_warnings) == 0
 
 # AsyncCohere Tests
 @pytest_asyncio.fixture

--- a/toponymy/tests/test_async_llm_wrappers_base.py
+++ b/toponymy/tests/test_async_llm_wrappers_base.py
@@ -43,7 +43,7 @@ class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
 
 class DummySingleWrapper(AsyncLLMWrapper):
     _supports_debug_callback = True
-    model="dummy-model"
+    model = "dummy-model"
 
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
@@ -56,6 +56,7 @@ class DummySingleWrapper(AsyncLLMWrapper):
 
 class DummyBatchWrapper(AsyncLLMWrapper):
     _supports_debug_callback = True
+
     async def _call_llm_batch(self, prompts, temperature, max_tokens):
         return ["batch-ok"]
 
@@ -332,9 +333,11 @@ async def test_async_generate_topic_cluster_names_partial_success(
     assert result[1] == fallback_old_names
     validate_cluster_names(result[2])
 
+
 #
 # ASYNC TESTS
 #
+
 
 @pytest.mark.asyncio
 async def test_safe_call_with_retry_result_emits_debug_callback_on_success():

--- a/toponymy/tests/test_async_llm_wrappers_base.py
+++ b/toponymy/tests/test_async_llm_wrappers_base.py
@@ -20,7 +20,8 @@ class DummyAsyncProviderError(Exception):
     pass
 
 class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
-    model = "dummy-model"
+    _supports_debug_callback = True
+
     FAIL_FAST_EXCEPTIONS = (DummyAsyncProviderError,)
 
     async def _call_single_llm(self, prompt, temperature, max_tokens):
@@ -32,6 +33,9 @@ class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
         raise DummyAsyncProviderError("bad config")
 
 class DummySingleWrapper(AsyncLLMWrapper):
+    _supports_debug_callback = True
+    model="dummy-model"
+
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
 
@@ -42,6 +46,7 @@ class DummySingleWrapper(AsyncLLMWrapper):
 
 
 class DummyBatchWrapper(AsyncLLMWrapper):
+    _supports_debug_callback = True
     async def _call_llm_batch(self, prompts, temperature, max_tokens):
         return ["batch-ok"]
 
@@ -178,7 +183,7 @@ async def test_safe_call_with_retry_result_raises_fail_fast():
     async def fail_fast_fn():
         raise DummyAsyncProviderError("bad config")
 
-    with pytest.raises(FailFastLLMError, match="dummy-model"):
+    with pytest.raises(FailFastLLMError, match="bad config"):
         await wrapper._safe_call_with_retry_result(fail_fast_fn)
 
 @pytest.mark.asyncio
@@ -304,3 +309,56 @@ async def test_async_generate_topic_cluster_names_partial_success(
     validate_cluster_names(result[0])
     assert result[1] == fallback_old_names
     validate_cluster_names(result[2])
+
+#
+# ASYNC TESTS
+#
+
+@pytest.mark.asyncio
+async def test_safe_call_with_retry_result_emits_debug_callback_on_success():
+    events = []
+
+    wrapper = DummySingleWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    async def fn(prompt, temperature, max_tokens, **kwargs):
+        return await wrapper._call_single_llm(prompt, temperature, max_tokens)
+
+    result = await wrapper._safe_call_with_retry_result(
+        fn,
+        prompt="test prompt",
+        temperature=0.4,
+        max_tokens=128,
+    )
+
+    assert result.ok
+    assert result.value == "single-ok"
+    assert len(events) == 1
+
+    event = events[0]
+    assert event["event"] == "llm_call_success"
+    assert event["prompt"] == "test prompt"
+    assert event["raw_response"] == "single-ok"
+    assert event["model"] == "dummy-model"
+    assert event["wrapper"] == "DummySingleWrapper"
+
+
+@pytest.mark.asyncio
+async def test_safe_call_with_retry_result_fail_fast_raises_and_no_callback():
+    events = []
+
+    wrapper = DummyAsyncFailFastWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    async def fn(prompt, temperature, max_tokens, **kwargs):
+        return await wrapper._call_single_llm(prompt, temperature, max_tokens)
+
+    with pytest.raises(FailFastLLMError, match="bad config"):
+        await wrapper._safe_call_with_retry_result(
+            fn,
+            prompt="test prompt",
+            temperature=0.4,
+            max_tokens=128,
+        )
+
+    assert len(events) == 0

--- a/toponymy/tests/test_debug_logging.py
+++ b/toponymy/tests/test_debug_logging.py
@@ -1,0 +1,61 @@
+import json
+from toponymy.debug_logging import BasicDebugLogger
+
+
+def test_basic_debug_logger_writes_jsonl(tmp_path):
+    log_path = tmp_path / "debug.jsonl"
+    logger = BasicDebugLogger(log_path, truncate=False)
+
+    logger(
+        {
+            "event": "llm_call_success",
+            "prompt": "test prompt",
+            "raw_response": "test response",
+        }
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    assert record["event"] == "llm_call_success"
+    assert record["prompt"] == "test prompt"
+    assert record["raw_response"] == "test response"
+
+
+def test_basic_debug_logger_truncates_strings(tmp_path):
+    log_path = tmp_path / "debug.jsonl"
+    logger = BasicDebugLogger(log_path, truncate=True, max_len=10)
+
+    logger(
+        {
+            "prompt": "abcdefghijklmnopqrstuvwxyz",
+            "raw_response": "0123456789abcdefghijklmnopqrstuvwxyz",
+        }
+    )
+
+    record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert "[truncated]" in record["prompt"]
+    assert "[truncated]" in record["raw_response"]
+
+
+def test_basic_debug_logger_truncates_dict_prompt(tmp_path):
+    log_path = tmp_path / "debug.jsonl"
+    logger = BasicDebugLogger(log_path, truncate=True, max_len=10)
+
+    logger(
+        {
+            "prompt": {
+                "system": "system-prompt-is-long",
+                "user": "user-prompt-is-long",
+            },
+            "raw_response": "ok",
+        }
+    )
+
+    record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert "[truncated]" in record["prompt"]["system"]
+    assert "[truncated]" in record["prompt"]["user"]
+    assert record["raw_response"] == "ok"

--- a/toponymy/tests/test_llm_wrapper_base.py
+++ b/toponymy/tests/test_llm_wrapper_base.py
@@ -1,9 +1,9 @@
-from toponymy.llm_wrappers import LLMWrapper, _should_retry, FailFastLLMError, InvalidLLMInputError
+from toponymy.llm_wrappers import LLMWrapper, _should_retry, FailFastLLMError, InvalidLLMInputError, AsyncLLMWrapper
 import pytest
 
 class DummySingleWrapper(LLMWrapper):
     model = "dummy-model"
-
+    _supports_debug_callback = True
     def _call_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
 
@@ -15,6 +15,7 @@ class DummySingleWrapper(LLMWrapper):
 
 class DummyFailureWrapper(LLMWrapper):
     model = "dummy-model"
+    _supports_debug_callback = True
 
     def _call_llm(self, prompt, temperature, max_tokens):
         raise RuntimeError("error")
@@ -40,6 +41,49 @@ class DummyFailFastWrapper(LLMWrapper):
     ):
         raise DummyFailFastProviderError("bad config")
 
+
+class DummyAsyncSingleWrapper(AsyncLLMWrapper):
+    model = "dummy-model"
+    _supports_debug_callback = True
+
+    async def _call_single_llm(self, prompt, temperature, max_tokens):
+        return "async-single-ok"
+
+    async def _call_single_llm_with_system_prompt(
+        self, system_prompt, user_prompt, temperature, max_tokens
+    ):
+        return "async-system-ok"
+
+
+class DummyAsyncFailureWrapper(AsyncLLMWrapper):
+    model = "dummy-model"
+    _supports_debug_callback = True
+
+    async def _call_single_llm(self, prompt, temperature, max_tokens):
+        raise RuntimeError("error")
+
+    async def _call_single_llm_with_system_prompt(
+        self, system_prompt, user_prompt, temperature, max_tokens
+    ):
+        raise RuntimeError("error")
+
+
+class DummyAsyncFailFastProviderError(Exception):
+    pass
+
+
+class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
+    model = "dummy-model"
+    _supports_debug_callback = True
+    FAIL_FAST_EXCEPTIONS = (DummyAsyncFailFastProviderError,)
+
+    async def _call_single_llm(self, prompt, temperature, max_tokens):
+        raise DummyAsyncFailFastProviderError("bad config")
+
+    async def _call_single_llm_with_system_prompt(
+        self, system_prompt, user_prompt, temperature, max_tokens
+    ):
+        raise DummyAsyncFailFastProviderError("bad config")
 
 def test_sync_connectivity_status_uses_plain_call():
     wrapper = DummySingleWrapper()
@@ -149,3 +193,96 @@ def test_handle_exception_reraises_retryable_exception():
 
     with pytest.raises(RuntimeError, match="retry me"):
         wrapper._handle_exception(RuntimeError("retry me"))
+
+def test_safe_call_llm_emits_debug_callback_on_success():
+    events = []
+
+    wrapper = DummySingleWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    result = wrapper._safe_call_llm(
+        "test prompt",
+        temperature=0.4,
+        max_tokens=128,
+        prompt_index=2,
+    )
+
+    assert result == "single-ok"
+    assert len(events) == 1
+    assert events[0]["event"] == "llm_call_success"
+    assert events[0]["prompt"] == "test prompt"
+    assert events[0]["prompt_index"] == 2
+    assert events[0]["raw_response"] == "single-ok"
+    assert events[0]["model"] == "dummy-model"
+    assert events[0]["wrapper"] == "DummySingleWrapper"
+
+def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_success():
+    events = []
+
+    wrapper = DummySingleWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    result = wrapper._safe_call_llm_with_system_prompt(
+        "system prompt",
+        "user prompt",
+        temperature=0.4,
+        max_tokens=128,
+        prompt_index=3,
+    )
+
+    assert result == "single-system-ok"
+    assert len(events) == 1
+    assert events[0]["event"] == "llm_call_success"
+    assert events[0]["prompt"] == {
+        "system": "system prompt",
+        "user": "user prompt",
+    }
+    assert events[0]["prompt_index"] == 3
+    assert events[0]["raw_response"] == "single-system-ok"
+
+
+def test_safe_call_llm_emits_debug_callback_on_error():
+    events = []
+
+    wrapper = DummyFailureWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    with pytest.raises(RuntimeError, match="error"):
+        wrapper._safe_call_llm(
+            "test prompt",
+            temperature=0.4,
+            max_tokens=128,
+            prompt_index=4,
+        )
+
+    assert len(events) == 1
+    assert events[0]["event"] == "llm_call_error"
+    assert events[0]["prompt"] == "test prompt"
+    assert events[0]["prompt_index"] == 4
+    assert events[0]["error"]["type"] == "RuntimeError"
+    assert events[0]["error"]["message"] == "error"
+
+def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
+    events = []
+
+    wrapper = DummyFailureWrapper()
+    wrapper.callback = lambda payload: events.append(payload)
+
+    with pytest.raises(RuntimeError, match="error"):
+        wrapper._safe_call_llm_with_system_prompt(
+            "system prompt",
+            "user prompt",
+            temperature=0.4,
+            max_tokens=128,
+            prompt_index=5,
+        )
+
+    assert len(events) == 1
+    assert events[0]["event"] == "llm_call_error"
+    assert events[0]["prompt"] == {
+        "system": "system prompt",
+        "user": "user prompt",
+    }
+    assert events[0]["prompt_index"] == 5
+    assert events[0]["error"]["type"] == "RuntimeError"
+    assert events[0]["error"]["message"] == "error"

--- a/toponymy/tests/test_llm_wrapper_base.py
+++ b/toponymy/tests/test_llm_wrapper_base.py
@@ -11,6 +11,7 @@ import pytest
 class DummySingleWrapper(LLMWrapper):
     model = "dummy-model"
     _supports_debug_callback = True
+
     def _call_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
 
@@ -92,6 +93,7 @@ class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
         self, system_prompt, user_prompt, temperature, max_tokens
     ):
         raise DummyAsyncFailFastProviderError("bad config")
+
 
 def test_sync_connectivity_status_uses_plain_call():
     wrapper = DummySingleWrapper()
@@ -208,6 +210,7 @@ def test_handle_exception_reraises_retryable_exception():
     with pytest.raises(RuntimeError, match="retry me"):
         wrapper._handle_exception(RuntimeError("retry me"))
 
+
 def test_safe_call_llm_emits_debug_callback_on_success():
     events = []
 
@@ -229,6 +232,7 @@ def test_safe_call_llm_emits_debug_callback_on_success():
     assert events[0]["raw_response"] == "single-ok"
     assert events[0]["model"] == "dummy-model"
     assert events[0]["wrapper"] == "DummySingleWrapper"
+
 
 def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_success():
 
@@ -277,6 +281,7 @@ def test_safe_call_llm_emits_debug_callback_on_error():
     assert events[0]["error"]["type"] == "RuntimeError"
     assert events[0]["error"]["message"] == "error"
 
+
 def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
     events = []
 
@@ -301,4 +306,3 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
     assert events[0]["prompt_index"] == 5
     assert events[0]["error"]["type"] == "RuntimeError"
     assert events[0]["error"]["message"] == "error"
-

--- a/toponymy/tests/test_llm_wrapper_base.py
+++ b/toponymy/tests/test_llm_wrapper_base.py
@@ -221,14 +221,12 @@ def test_safe_call_llm_emits_debug_callback_on_success():
         "test prompt",
         temperature=0.4,
         max_tokens=128,
-        prompt_index=2,
     )
 
     assert result == "single-ok"
     assert len(events) == 1
     assert events[0]["event"] == "llm_call_success"
     assert events[0]["prompt"] == "test prompt"
-    assert events[0]["prompt_index"] == 2
     assert events[0]["raw_response"] == "single-ok"
     assert events[0]["model"] == "dummy-model"
     assert events[0]["wrapper"] == "DummySingleWrapper"
@@ -246,7 +244,6 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_success():
         "user prompt",
         temperature=0.4,
         max_tokens=128,
-        prompt_index=3,
     )
 
     assert result == "single-system-ok"
@@ -256,7 +253,6 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_success():
         "system": "system prompt",
         "user": "user prompt",
     }
-    assert events[0]["prompt_index"] == 3
     assert events[0]["raw_response"] == "single-system-ok"
 
 
@@ -271,13 +267,11 @@ def test_safe_call_llm_emits_debug_callback_on_error():
             "test prompt",
             temperature=0.4,
             max_tokens=128,
-            prompt_index=4,
         )
 
     assert len(events) == 1
     assert events[0]["event"] == "llm_call_error"
     assert events[0]["prompt"] == "test prompt"
-    assert events[0]["prompt_index"] == 4
     assert events[0]["error"]["type"] == "RuntimeError"
     assert events[0]["error"]["message"] == "error"
 
@@ -294,7 +288,6 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
             "user prompt",
             temperature=0.4,
             max_tokens=128,
-            prompt_index=5,
         )
 
     assert len(events) == 1
@@ -303,6 +296,5 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
         "system": "system prompt",
         "user": "user prompt",
     }
-    assert events[0]["prompt_index"] == 5
     assert events[0]["error"]["type"] == "RuntimeError"
     assert events[0]["error"]["message"] == "error"

--- a/toponymy/tests/test_llm_wrappers.py
+++ b/toponymy/tests/test_llm_wrappers.py
@@ -142,13 +142,11 @@ def test_supported_namers_do_not_warn_on_callback(namer_cls, kwargs):
         warnings.simplefilter("always")
         namer_cls(callback=callback, **kwargs)
 
-    debug_warnings = [
-        w for w in record
-        if "debug callback" in str(w.message)
-    ]
+    debug_warnings = [w for w in record if "debug callback" in str(w.message)]
 
     assert len(debug_warnings) == 0
     assert namer_cls._supports_debug_callback is True
+
 
 @pytest.mark.parametrize("namer_cls, kwargs", UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS)
 def test_unsupported_namers_warn_on_callback(namer_cls, kwargs):
@@ -158,6 +156,7 @@ def test_unsupported_namers_warn_on_callback(namer_cls, kwargs):
         namer_cls(callback=callback, **kwargs)
     assert namer_cls._supports_debug_callback is False
 
+
 @pytest.mark.parametrize(
     "namer_cls, kwargs",
     SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS + UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS,
@@ -166,10 +165,7 @@ def test_no_warning_when_no_callback(namer_cls, kwargs):
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         namer_cls(callback=None, **kwargs)
-    debug_warnings = [
-        w for w in record
-        if "debug callback" in str(w.message)
-    ]
+    debug_warnings = [w for w in record if "debug callback" in str(w.message)]
 
     assert len(debug_warnings) == 0
 

--- a/toponymy/tests/test_llm_wrappers.py
+++ b/toponymy/tests/test_llm_wrappers.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from unittest.mock import Mock, patch
 import os
@@ -5,7 +7,13 @@ import os
 
 from toponymy.llm_wrappers import LiteLLMNamer, repair_json_string_backslashes, FailFastLLMError
 from toponymy.llm_wrappers import AnthropicNamer, OpenAINamer, CohereNamer, HuggingFaceNamer, AzureAINamer, LlamaCppNamer, OllamaNamer, GoogleGeminiNamer, TogetherNamer, ReplicateNamer, OllamaNamer, GoogleGeminiNamer
-from toponymy.tests.helpers.llm_test_config import (validate_cluster_names, validate_topic_name, LITELLM_PROVIDER_CASES)
+from toponymy.tests.helpers.llm_test_config import (
+    validate_cluster_names,
+    validate_topic_name,
+    LITELLM_PROVIDER_CASES,
+    SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS,
+    UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS,
+)
 from toponymy.tests.helpers.errors import (
     make_openai_error,
     OPENAI_FAIL_FAST,
@@ -103,6 +111,46 @@ class MockLLMResponse:
                 self.model.generate_content = Mock(return_value=MockText(text))
 
         return MockResponse(content)
+
+# Test callback support in all wrappers
+@pytest.mark.parametrize("namer_cls, kwargs", SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS)
+def test_supported_namers_do_not_warn_on_callback(namer_cls, kwargs):
+    callback = lambda payload: None
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        namer_cls(callback=callback, **kwargs)
+
+    debug_warnings = [
+        w for w in record
+        if "debug callback" in str(w.message)
+    ]
+
+    assert len(debug_warnings) == 0
+    assert namer_cls._supports_debug_callback is True
+
+@pytest.mark.parametrize("namer_cls, kwargs", UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS)
+def test_unsupported_namers_warn_on_callback(namer_cls, kwargs):
+    callback = lambda payload: None
+
+    with pytest.warns(UserWarning, match="debug callback") as record:
+        namer_cls(callback=callback, **kwargs)
+    assert namer_cls._supports_debug_callback is False
+
+@pytest.mark.parametrize(
+    "namer_cls, kwargs",
+    SUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS + UNSUPPORTED_SYNC_DEBUG_CALLBACK_NAMERS,
+)
+def test_no_warning_when_no_callback(namer_cls, kwargs):
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        namer_cls(callback=None, **kwargs)
+    debug_warnings = [
+        w for w in record
+        if "debug callback" in str(w.message)
+    ]
+
+    assert len(debug_warnings) == 0
 
 # LlamaCpp Tests
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -6140,7 +6140,7 @@ wheels = [
 
 [[package]]
 name = "toponymy"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "apricot-select" },


### PR DESCRIPTION

Adds an optional callback hook to LLM wrappers for getting the raw responses and errors paired with the prompts. This gives lightweight debugging, monitoring, and response pattern tracking without coupling to a specific backend.

Here's an example event:

```json
{
  "event": "llm_call_success",
  "model": "openai/gpt-4o-mini",
  "prompt": {
    "system": "You are an expert at classifying newsgroup posts...",
    "user": "Here is the information about the group of newsgroup posts..."
  },
  "prompt_type": "system",
  "raw_response": "{\"topic_name\":\"FBI's Role in Branch Davidian Fire Controversy and Evidence Disputes\",\"topic_specificity\":0.9}",
  "routine": "generate_topic_names",
  "wrapper": "LiteLLMNamer"
}
```

A small `BasicDebugLogger` utility is included for low-volume local debugging. High-volume use cases should swap in a buffered or queue-backed callback. 

Here's a usage example: 

```python
from toponymy.llm_wrappers import LiteLLMNamer
from toponymy.debug_logging import BasicDebugLogger

# write prompt/response events to a JSONL file
logger = BasicDebugLogger("llm_debug.jsonl", truncate=True)

llm = LiteLLMNamer(callback=logger)

# run your pipeline as usual
# events will be appended to llm_debug.jsonl
```
