### PR TITLE
Configure VSCode to run Black formatter on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,15 @@
     "python.testing.pytestArgs": [],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.experiments.optInto": ["pythonTestAdapter"]
+    "python.experiments.optInto": ["pythonTestAdapter"],
+    
+    // Format on save settings
+    "editor.formatOnSave": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true
+    },
+    
+    // Use local .venv Python
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }


### PR DESCRIPTION
- Enable formatOnSave for all files and specifically for Python
- Set Black as default Python formatter
- Configure Python interpreter to use local .venv