### PR TITLE
Fix shallow topic tree HTML rendering

### DIFF
--- a/toponymy/tests/test_topic_tree.py
+++ b/toponymy/tests/test_topic_tree.py
@@ -301,6 +301,31 @@ def test_topic_tree_html():
     assert result == expected_result
 
 
+def test_topic_tree_html_single_layer():
+    tree_dict = {(1, 0): [(0, 0), (0, 1)]}
+    topics = [["Leaf A", "Leaf B"], ["Root"]]
+    topic_sizes = [[1, 1], [2]]
+
+    result = topic_tree_html(tree_dict, topics, topic_sizes, 2)
+
+    assert "Root" in result
+    assert "Leaf A" in result
+    assert "Leaf B" in result
+
+
+def test_topic_tree_repr_html_single_layer():
+    tree_dict = {(1, 0): [(0, 0), (0, 1)]}
+    topics = [["Leaf A", "Leaf B"], ["Root"]]
+    topic_sizes = [[1, 1], [2]]
+
+    tree = TopicTree(tree_dict, topics, topic_sizes, 2)
+    result = tree._repr_html_()
+
+    assert "Root" in result
+    assert "Leaf A" in result
+    assert "Leaf B" in result
+
+
 def test_topic_tree_html_with_colors():
     tree_dict = {
         (3, 0): [(2, 0), (2, 1)],

--- a/toponymy/topic_tree.py
+++ b/toponymy/topic_tree.py
@@ -254,17 +254,16 @@ def topic_tree_html_recursion(
     else:
         topic_name = "<b>Topic Tree</b>"
 
+    gray_val = 0
+    weight_val = 800
     if max_layer > 0:
         if layer == max_layer:
-            gray_val = 0
             weight_val = 900
         else:
-            gray_val = np.sqrt(1.0 - (layer / (max_layer - 1))) * 200
-            weight_val = 200 + (layer / (max_layer - 1)) * 600
+            depth_scale = max(max_layer - 1, 1)
+            gray_val = np.sqrt(1.0 - (layer / depth_scale)) * 200
+            weight_val = 200 + (layer / depth_scale) * 600
             weight_val = round(weight_val / 100) * 100
-    elif layer == 0:
-        gray_val = 0
-        weight_val = 800
 
     gray_val = int(max(0, min(255, gray_val)))
 


### PR DESCRIPTION
This fixes a crash in the HTML rendering for very shallow topic trees.

The depth based styling in topic_tree_html_recursion() could divide by zero when the tree only had one level below the root. That meant _repr_html_() and topic_tree_html() could fail instead of rendering normally.

This change keeps the existing root styling behavior and makes the depth calculation safe for shallow trees.
Also added two regression tests for the single layer case, both pass on my end:
  - test_topic_tree_html_single_layer
  - test_topic_tree_repr_html_single_layer
