### PR TITLE
Move transformers and tokenizers to base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "tenacity",
     "httpx",
     "apricot-select",
+    "jinja2",
+    "transformers>=4.41.0,<5.0.0", # upper bound transformers for compatibility with sentence-transformers
+    "tokenizers",
 ]
 
 [project.urls]
@@ -84,7 +87,6 @@ dev = [
     "sentence-transformers<=5.1.2",
     "together",
     "traitlets",
-    "transformers>=4.41.0,<5.0.0",
     "umap-learn",
     "pylance",
     "litellm>=1.83.10",


### PR DESCRIPTION
- Add jinja2, transformers, and tokenizers to base dependencies
- Remove transformers from dev dependencies (now in base)

These packages are required for core functionality since:
- jinja2 is imported unconditionally by templates.py
- transformers and tokenizers are imported unconditionally by llm_wrappers.py
- cluster_layer.py imports llm_wrappers at module level, making these transitive deps

This fixes ModuleNotFoundError when importing from toponymy.clustering or toponymy.cluster_layer in a base install without dev extras.

Kept transformers<5.0.0 constraint for compatibility with sentence-transformers.