### PR TITLE
Update summary based templates to reflect CoT style responses better.

### DIFF
--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -966,7 +966,7 @@ class ClusterLayerSummaryText(ClusterLayerText):
                             else lambda json_response: (
                                 json_response["topic_name"],
                                 json_response["topic_summary"],
-                                json_response["topic_explanation"],
+                                json_response["topic_analysis"],
                             )
                         ),
                         get_topic_name_regex=(
@@ -1006,7 +1006,7 @@ class ClusterLayerSummaryText(ClusterLayerText):
                         else lambda json_response: (
                             json_response["topic_name"],
                             json_response["topic_summary"],
-                            json_response["topic_explanation"],
+                            json_response["topic_analysis"],
                         )
                     ),
                     get_topic_name_regex=(
@@ -1078,7 +1078,7 @@ class ClusterLayerSummaryText(ClusterLayerText):
                                 else lambda json_response: (
                                     json_response["topic_name"],
                                     json_response["topic_summary"],
-                                    json_response["topic_explanation"],
+                                    json_response["topic_analysis"],
                                 )
                             ),
                             get_topic_name_regex=(

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -1014,6 +1014,7 @@ class ClusterLayerSummaryText(ClusterLayerText):
                         if self.prompt_template
                         else None
                     ),
+                    null_result_value=("", "", ""),
                     max_tokens=2048,
                 )
             )

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -1,4 +1,5 @@
 import string
+from unittest import result
 from warnings import warn, filterwarnings
 
 import tokenizers
@@ -10,7 +11,7 @@ from toponymy.templates import (
     default_extract_topic_names,
 )
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union, Dict, Generic, TypeVar, Callable,Any
+from typing import List, Optional, Union, Dict, Generic, TypeVar, Callable, Any
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -208,6 +209,7 @@ class DebugCallbackMixin:
     The helper `_warn_if_debug_callback_unsupported` provides a check to warn if
     a debug callback is provided but not supported.
     """
+
     _supports_debug_callback: bool = False
     callback: DebugCallback | None = None
 
@@ -309,12 +311,12 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         pass
 
     def _safe_call_llm(
-            self,
-            prompt: str,
-            temperature: float,
-            max_tokens: int,
-            routine: str | None = None
-        ) -> str:
+        self,
+        prompt: str,
+        temperature: float,
+        max_tokens: int,
+        routine: str | None = None,
+    ) -> str:
         try:
             raw_response = self._call_llm(prompt, temperature, max_tokens)
 
@@ -345,11 +347,12 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
             self._handle_exception(e)
 
     def _safe_call_llm_with_system_prompt(
-        self, system_prompt: str,
+        self,
+        system_prompt: str,
         user_prompt: str,
         temperature: float,
         max_tokens: int,
-        routine: str | None = None
+        routine: str | None = None,
     ) -> str:
         prompt_payload = {
             "system": system_prompt,
@@ -412,10 +415,13 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         topic_extraction_function=lambda x: x["topic_name"],
         get_topic_name_regex=GET_TOPIC_NAME_REGEX,
         max_tokens: int = 128,
-    ) -> str:
+    ) -> str | tuple:
         if isinstance(prompt, str):
             topic_name_info_raw = self._safe_call_llm(
-                prompt, temperature, max_tokens=max_tokens, routine="generate_topic_names",
+                prompt,
+                temperature,
+                max_tokens=max_tokens,
+                routine="generate_topic_names",
             )
         elif isinstance(prompt, dict) and self.supports_system_prompts:
             topic_name_info_raw = self._safe_call_llm_with_system_prompt(
@@ -472,7 +478,10 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     ) -> List[str]:
         if isinstance(prompt, str):
             topic_name_info_raw = self._safe_call_llm(
-                prompt, temperature, max_tokens=max_tokens, routine="generate_topic_cluster_names",
+                prompt,
+                temperature,
+                max_tokens=max_tokens,
+                routine="generate_topic_cluster_names",
             )
         elif isinstance(prompt, dict) and self.supports_system_prompts:
             topic_name_info_raw = self._safe_call_llm_with_system_prompt(
@@ -601,6 +610,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
         return result
 
+
 class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_single_llm(
@@ -674,7 +684,11 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         )
 
     async def _call_llm_batch(
-        self, prompts: List[str], temperature: float, max_tokens: int, routine: str | None = None
+        self,
+        prompts: List[str],
+        temperature: float,
+        max_tokens: int,
+        routine: str | None = None,
     ) -> List[CallResult[str]]:
         """
         Process a batch of prompts and return one CallResult per prompt.
@@ -794,6 +808,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         temperature: float = 0.4,
         extract_topic_name_function=lambda x: x["topic_name"],
         get_topic_name_regex=GET_TOPIC_NAME_REGEX,
+        null_result_value="",
         max_tokens: int = 128,
     ) -> List[str]:
         """
@@ -828,14 +843,14 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                         f"Failed to generate topic name with "
                         f"{self.__class__.__name__}: {response.error}"
                     )
-                    results.append("")
+                    results.append(null_result_value)
                     continue
                 response_text = response.value
             else:
                 response_text = response
 
             if not response_text:
-                results.append("")
+                results.append(null_result_value)
                 continue
 
             # Attempt to parse the response
@@ -843,12 +858,16 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 topic_name_info = llm_output_to_result(
                     response_text, get_topic_name_regex
                 )
-                results.append(str(extract_topic_name_function(topic_name_info)))
+                result = extract_topic_name_function(topic_name_info)
+                topic_name = result if isinstance(result, tuple) else str(result)
+                results.append(topic_name)
             except Exception as e:
                 warn(
                     f"Failed to generate topic name with {self.__class__.__name__}: {e}"
                 )
-                results.append("")  # Fallback to empty string if parsing fails
+                results.append(
+                    null_result_value
+                )  # Fallback to null_result_value if parsing fails
 
         return results
 
@@ -1161,7 +1180,13 @@ try:
             Indicates whether the wrapper supports system prompts. For LlamaCpp, this is always False.
         """
 
-        def __init__(self, model_path: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
+        def __init__(
+            self,
+            model_path: str,
+            llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
+            **kwargs,
+        ):
             self.model_path = model_path
             for arg, val in kwargs.items():
                 if arg == "n_ctx":
@@ -1245,7 +1270,13 @@ try:
             Indicates whether the wrapper supports system prompts. For Huggingface, this is always True.
         """
 
-        def __init__(self, model: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
+        def __init__(
+            self,
+            model: str,
+            llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
+            **kwargs,
+        ):
             self.model = model
             self.callback = callback
             self._warn_if_debug_callback_unsupported()
@@ -1399,7 +1430,13 @@ try:
             Indicates whether the wrapper supports system prompts. For Huggingface, this is always True.
         """
 
-        def __init__(self, model: str, llm_specific_instructions=None, callback: DebugCallback | None = None, **kwargs):
+        def __init__(
+            self,
+            model: str,
+            llm_specific_instructions=None,
+            callback: DebugCallback | None = None,
+            **kwargs,
+        ):
             self.model = model
             self.callback = callback
             self._warn_if_debug_callback_unsupported()
@@ -2653,6 +2690,7 @@ try:
         This wrapper does not support batch processing. If you need to process multiple prompts concurrently,
         consider using the AsyncOpenAI wrapper instead.
         """
+
         FAIL_FAST_EXCEPTIONS = (
             AuthenticationError,
             PermissionDeniedError,
@@ -2770,6 +2808,7 @@ try:
         supports_system_prompts: bool
             Indicates whether the wrapper supports system prompts. For OpenAI, this is always True.
         """
+
         FAIL_FAST_EXCEPTIONS = (
             AuthenticationError,
             PermissionDeniedError,
@@ -4538,6 +4577,7 @@ try:
             UnprocessableEntityError,
         )
         _supports_debug_callback = True
+
         def __init__(
             self,
             api_key: str = None,

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -12,7 +12,7 @@ SUMMARY_KINDS = [
 ]
 
 GET_TOPIC_NAME_REGEX = r'\{\s*"topic_name":\s*.*?,\s*"topic_specificity":\s*[\w.]+\s*\}'
-GET_TOPIC_NAME_AND_SUMMARY_REGEX = r'\{\s*"topic_name":\s*.*?,\s*"topic_summary":\s*.*?,\s*"topic_explanation":\s*.*?,\s*"topic_specificity":\s*[\w.]+\s*\}'
+GET_TOPIC_NAME_AND_SUMMARY_REGEX = r'\{\s*"topic_analysis":\s*.*?,\s*"topic_summary":\s*.*?,\s*"topic_name":\s*.*?,\s*"topic_specificity":\s*[\w.]+\s*\}'
 GET_TOPIC_CLUSTER_NAMES_REGEX = (
     r'\{\s*"new_topic_name_mapping":\s*.*?,\s*"topic_specificities": .*?\}'
 )
@@ -152,8 +152,7 @@ large and diverse range of {{document_type}} contained in it at a glance.
 {%- endif %}
 The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} 
 where SCORE is a value in the range 0 to 1.
-"""
-        ),
+"""),
         "extract_topic_name": lambda json_response: str(json_response["topic_name"]),
         "get_topic_name_regex": GET_TOPIC_NAME_REGEX,
     },
@@ -513,30 +512,31 @@ SUMMARY_PROMPT_TEMPLATES = {
     "layer": {
         "system": jinja2.Template("""
 You are an expert at classifying {{document_type}} from {{corpus_description}} into topics.
-Your task is to analyze information about a group of {{document_type}} and assign a {{summary_kind}} name to this group,
-as well as providing a short paragraph summary of the topic, and a more detailed explanation of the content of the topic.
+Your task is to analyze information about a group of {{document_type}} and provide a thorough analysis of the topic,
+a short paragraph summary, and a {{summary_kind}} name for the group.
 
-The response must be in JSON formatted as {"topic_name":<NAME>, "topic_summary":<SUMMARY>, "topic_explanation":<EXPLANATION>, "topic_specificity":<SCORE>}
-where NAME is the topic name you generate, SUMMARY is a short paragraph summary of the topic, 
-EXPLANATION is a more detailed explanation of the content of the topic, and SCORE is a float value between 0.0 and 1.0,
+The response must be in JSON formatted as {"topic_analysis":<ANALYSIS>, "topic_summary":<SUMMARY>, "topic_name":<NAME>, "topic_specificity":<SCORE>}
+where ANALYSIS is a thorough analytical discussion of the topic's content, key themes, sub-areas, and relationships
+(written to inform the summary and name that follow), SUMMARY is a short paragraph summary of the topic,
+NAME is the topic name you generate, and SCORE is a float value between 0.0 and 1.0,
 representing how specific and well-defined the topic name is given the input information.
 A score of 1.0 means a perfectly descriptive and specific name, while 0.0 would be a completely generic or unrelated name.
 {% if is_very_specific_summary %}
+The topic analysis should thoroughly examine the specific details, distinctions, and nuances of the topic.
+The topic summary should be precise and capture the specific aspects of the topic.
 The topic name should be specific to the information given and sufficiently detailed to ensure
-it can be distinguished from other similarly detailed topics. The topic summary should be precise
-and capture the specific aspects of the topic, while the explanation should provide a 
-comprehensive overview of the topic's content and nuances.
+it can be distinguished from other similarly detailed topics.
 {% elif is_general_summary %}
+The topic analysis should survey the full breadth and diversity of sub-areas covered by the topic.
+The topic summary should provide a concise overview of the main themes and ideas encompassed by the topic.
 The topic name should be broad and simple enough to capture the overall sense of the
-large and diverse range of {{document_type}} contained in it at a glance. The topic summary should provide
-a concise overview of the main themes and ideas encompassed by the topic, while the explanation should elaborate 
-on the sumamry providing a more detailed accounting of the full breadth and range of subtopics covered by the topic.
+large and diverse range of {{document_type}} contained in it at a glance.
 {% endif %}
 {% if has_major_subtopics %}
-You should primarily make use of the major and minor subtopics of this group to generate a name,
+You should primarily make use of the major and minor subtopics of this group in your analysis,
 and ensure the topic name reflects the core essence of *all* major subtopics. The topic summary
-should focus on the major and minor subtopics to capture the key themes. The topic explanation
-should focus on the full breadth of subtopics to ensure it captures the full breadth and diversity of 
+should focus on the major and minor subtopics to capture the key themes. The topic analysis
+should cover the full breadth of subtopics to ensure it captures the full breadth and diversity of
 content within the topic.
 {% endif %}
 Ensure your entire response is only the JSON object, with no other text before or after it.
@@ -578,13 +578,13 @@ Here is the information about the group of {{document_type}}:
 {%- endif %}
 
 Based on this information, provide a {{summary_kind}} name for this group.
-Recall the output format: {"topic_name":<NAME>, "topic_summary":<SUMMARY>, "topic_explanation":<EXPLANATION>, "topic_specificity":<SCORE>}.
+Recall the output format: {"topic_analysis":<ANALYSIS>, "topic_summary":<SUMMARY>, "topic_name":<NAME>, "topic_specificity":<SCORE>}.
 """),
         "combined": jinja2.Template("""
 You are an expert of classifying {{document_type}} from {{corpus_description}} into topics.
 Below is a information about a group of {{document_type}} from {{corpus_description}} that 
-are all on the same topic and need to be given topic name, as well as a short paragraph summary 
-of the topic, and a more detailed explanation of the content of the topic.
+are all on the same topic and need to be given a thorough analysis of the topic,
+a short paragraph summary, and a topic name.
 
 {% if cluster_keywords %}
  - Keywords for this group include: {{", ".join(cluster_keywords)}}
@@ -620,35 +620,35 @@ of the topic, and a more detailed explanation of the content of the topic.
 {%- endfor %}
 {%- endif %}
 
-You are to give a {{summary_kind}} name to this group of {{document_type}}, as well as a short paragraph summary of the topic, 
-and a more detailed explanation of the content of the topic.
+You are to provide a thorough analysis of this topic, a short paragraph summary, and a {{summary_kind}} name for this group of {{document_type}}.
 {% if has_major_subtopics -%}
-You should primarily make use of the major and minor subtopics of this group to generate a name,
+You should primarily make use of the major and minor subtopics of this group in your analysis,
 and ensure the topic name reflects the core essence of *all* major subtopics. The topic summary
-should focus on the major and minor subtopics to capture the key themes. The topic explanation
-should focus on the full breadth of subtopics to ensure it captures the full breadth and diversity of 
+should focus on the major and minor subtopics to capture the key themes. The topic analysis
+should cover the full breadth of subtopics to ensure it captures the full breadth and diversity of
 content within the topic.
 {%- endif %}
 {% if is_very_specific_summary %}
+The topic analysis should thoroughly examine the specific details, distinctions, and nuances of the topic.
+The topic summary should be precise and capture the specific aspects of the topic.
 The topic name should be specific to the information given and sufficiently detailed to ensure
-it can be distinguished from other similarly detailed topics. The topic summary should be precise
-and capture the specific aspects of the topic, while the explanation should provide a 
-comprehensive overview of the topic's content and nuances.
+it can be distinguished from other similarly detailed topics.
 {% elif is_general_summary %}
+The topic analysis should survey the full breadth and diversity of sub-areas covered by the topic.
+The topic summary should provide a concise overview of the main themes and ideas encompassed by the topic.
 The topic name should be broad and simple enough to capture the overall sense of the
-large and diverse range of {{document_type}} contained in it at a glance. The topic summary should provide
-a concise overview of the main themes and ideas encompassed by the topic, while the explanation should elaborate 
-on the sumamry providing a more detailed accounting of the full breadth and range of subtopics covered by the topic.
+large and diverse range of {{document_type}} contained in it at a glance.
 {% endif %}
-The response should be in JSON formatted as {"topic_name":<NAME>, "topic_summary":<SUMMARY>, "topic_explanation":<EXPLANATION>, "topic_specificity":<SCORE>}.
-where NAME is the topic name you generate, SUMMARY is a short paragraph summary of the topic, 
-EXPLANATION is a more detailed explanation of the content of the topic, and SCORE is a float value between 0.0 and 1.0,
+The response should be in JSON formatted as {"topic_analysis":<ANALYSIS>, "topic_summary":<SUMMARY>, "topic_name":<NAME>, "topic_specificity":<SCORE>}
+where ANALYSIS is a thorough analytical discussion of the topic's content, key themes, sub-areas, and relationships
+(written to inform the summary and name that follow), SUMMARY is a short paragraph summary of the topic,
+NAME is the topic name you generate, and SCORE is a float value between 0.0 and 1.0,
 representing how specific and well-defined the topic name is given the input information.
 """),
         "extract_topic_name": lambda json_response: (
             json_response["topic_name"],
             json_response["topic_summary"],
-            json_response["topic_explanation"],
+            json_response["topic_analysis"],
         ),
         "get_topic_name_regex": GET_TOPIC_NAME_AND_SUMMARY_REGEX,
     },

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -539,7 +539,7 @@ should focus on the major and minor subtopics to capture the key themes. The top
 should cover the full breadth of subtopics to ensure it captures the full breadth and diversity of
 content within the topic.
 {% endif %}
-Ensure your entire response is only the JSON object, with no other text before or after it.
+ Ensure your entire response is only the JSON object, with no other text before or after it. Keep all JSON string values on a single line (escape any newlines as \\n).
 """),
         "user": jinja2.Template("""
 Here is the information about the group of {{document_type}}:

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -577,7 +577,7 @@ Here is the information about the group of {{document_type}}:
 {%- endfor %}
 {%- endif %}
 
-Based on this information, provide a {{summary_kind}} name for this group.
+Based on this information, provide a detailed topic analysis, a summary, and a {{summary_kind}} name for this group.
 Recall the output format: {"topic_analysis":<ANALYSIS>, "topic_summary":<SUMMARY>, "topic_name":<NAME>, "topic_specificity":<SCORE>}.
 """),
         "combined": jinja2.Template("""


### PR DESCRIPTION
I realized that if we re-order the JSON output we can force the LLM to provide a detailed analysis of the topic, followed by a summary, followed by the topic name, and thus have the topic named informed by that analysis and summary. Ultimately it is a small change, but I believe it can have a definite positive impact on topic names. This is really a relatively minimal change set to achieve that -- mostly just tweaking the prompt, and then aligning a few other things based on changes made to the prompt.