### PR TITLE
Add PLSCANClusterer wrapper

### DIFF
--- a/doc/api_main_classes.rst
+++ b/doc/api_main_classes.rst
@@ -13,6 +13,11 @@ Main Classes
    :undoc-members:
    :show-inheritance:
 
+.. autoclass:: toponymy.PLSCANClusterer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: toponymy.ClusterLayerText
    :members:
    :undoc-members:
@@ -22,4 +27,3 @@ Main Classes
    :members:
    :undoc-members:
    :show-inheritance:  
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,7 @@ and a tour of some of the richer functionality and uses cases.
 
    how_toponymy_works
    clusterers
+   plscan_clusterer
    clustering_options
    keyphrases
    exemplar_texts

--- a/doc/plscan_clusterer.rst
+++ b/doc/plscan_clusterer.rst
@@ -3,7 +3,7 @@ PLSCANClusterer
 ================
 
 ``PLSCANClusterer`` is a Toponymy ``Clusterer`` wrapper around
-``fast_plscan.PLSCAN``. It is useful when you want PLSCAN-based layered
+``fast_hdbscan.PLSCAN``. It is useful when you want PLSCAN-based layered
 clustering inside Toponymy while still using the standard Toponymy clusterer
 interface. It does not replace ``ToponymyClusterer``; it is an alternative
 clusterer for users who specifically want PLSCAN's persistence-based cluster
@@ -46,7 +46,8 @@ Basic usage
 
    # PLSCAN metadata retained for the returned layers
    clusterer.cluster_probabilities_
-   clusterer.cluster_cut_sizes_
+   clusterer.cluster_persistence_scores_
+   clusterer.plscan_min_cluster_sizes_
 
 ``cluster_layers`` is the list of Toponymy cluster layer objects. ``cluster_tree``
 maps clusters between neighboring layers.
@@ -54,9 +55,10 @@ maps clusters between neighboring layers.
 Notes
 -----
 
-* ``clusterable_vectors`` are passed to ``fast_plscan.PLSCAN.fit(...)``.
+* ``clusterable_vectors`` are passed to ``fast_hdbscan.PLSCAN.fit(...)``.
 * ``embedding_vectors`` are used for Toponymy centroid construction.
 * ``-1`` labels are preserved as noise or unlabelled points.
-* ``cluster_probabilities_`` and ``cluster_cut_sizes_`` are stored on the
-  clusterer object for the returned layers.
-* ``n_threads=-1`` uses the upstream PLSCAN default thread behavior.
+* ``cluster_probabilities_`` and ``cluster_persistence_scores_`` are stored on
+  the clusterer object for the returned layers.
+* ``plscan_min_cluster_sizes_`` stores the ``min_cluster_sizes_`` trace exposed
+  by ``fast_hdbscan.PLSCAN``.

--- a/doc/plscan_clusterer.rst
+++ b/doc/plscan_clusterer.rst
@@ -1,0 +1,62 @@
+================
+PLSCANClusterer
+================
+
+``PLSCANClusterer`` is a Toponymy ``Clusterer`` wrapper around
+``fast_plscan.PLSCAN``. It is useful when you want PLSCAN-based layered
+clustering inside Toponymy while still using the standard Toponymy clusterer
+interface. It does not replace ``ToponymyClusterer``; it is an alternative
+clusterer for users who specifically want PLSCAN's persistence-based cluster
+layers.
+
+When to use it
+--------------
+
+Use ``PLSCANClusterer`` when you want to:
+
+* cluster on ``clusterable_vectors``, often a low-dimensional map or another
+  clusterable representation;
+* compute Toponymy centroids from ``embedding_vectors``;
+* inspect PLSCAN layers through the same ``cluster_layers_`` and
+  ``cluster_tree_`` interface used by other Toponymy clusterers.
+
+Basic usage
+-----------
+
+.. code-block:: python
+
+   from toponymy import ClusterLayerText, PLSCANClusterer
+
+   clusterer = PLSCANClusterer(
+       min_clusters=6,
+       min_samples=5,
+       base_min_cluster_size=10,
+       max_layers=4,
+   )
+
+   cluster_layers, cluster_tree = clusterer.fit_predict(
+       clusterable_vectors=clusterable_vectors,
+       embedding_vectors=embedding_vectors,
+       layer_class=ClusterLayerText,
+   )
+
+   # Toponymy layer objects and the parent/child cluster tree
+   clusterer.cluster_layers_
+   clusterer.cluster_tree_
+
+   # PLSCAN metadata retained for the returned layers
+   clusterer.cluster_probabilities_
+   clusterer.cluster_cut_sizes_
+
+``cluster_layers`` is the list of Toponymy cluster layer objects. ``cluster_tree``
+maps clusters between neighboring layers.
+
+Notes
+-----
+
+* ``clusterable_vectors`` are passed to ``fast_plscan.PLSCAN.fit(...)``.
+* ``embedding_vectors`` are used for Toponymy centroid construction.
+* ``-1`` labels are preserved as noise or unlabelled points.
+* ``cluster_probabilities_`` and ``cluster_cut_sizes_`` are stored on the
+  clusterer object for the returned layers.
+* ``n_threads=-1`` uses the upstream PLSCAN default thread behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "vectorizers",
     "scipy",
     "fast_hdbscan>=0.3.2",
-    "fast-plscan>=0.2.0,<0.3",
     "tqdm",
     "tenacity",
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "vectorizers",
     "scipy",
     "fast_hdbscan>=0.3.2",
+    "fast-plscan>=0.2.0,<0.3",
     "tqdm",
     "tenacity",
     "httpx",

--- a/toponymy/__init__.py
+++ b/toponymy/__init__.py
@@ -1,5 +1,5 @@
 from .toponymy import Toponymy
-from .clustering import ToponymyClusterer
+from .clustering import ToponymyClusterer, PLSCANClusterer
 from .keyphrases import KeyphraseBuilder
 from .cluster_layer import ClusterLayerText
 from .serialization import TopicModel
@@ -14,6 +14,7 @@ except PackageNotFoundError:
 __all__ = [
     "Toponymy",
     "ToponymyClusterer",
+    "PLSCANClusterer",
     "KeyphraseBuilder",
     "ClusterLayerText",
     "TopicModel",

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, List, NewType, Optional, Tuple, Type
 
 import numba
 import numpy as np
+from fast_hdbscan import PLSCAN
 from fast_hdbscan.boruvka import parallel_boruvka
 from fast_hdbscan.cluster_trees import condense_tree, extract_leaves
 from fast_hdbscan.numba_kdtree import build_kdtree
-from fast_plscan import PLSCAN
 from sklearn.cluster import KMeans
 from sklearn.neighbors import KDTree
 
@@ -598,7 +598,7 @@ class KMeansClusterer(Clusterer):
 
 class PLSCANClusterer(Clusterer):
     """
-    A class for clustering dense vector data in layers using fast_plscan.PLSCAN.
+    A class for clustering dense vector data in layers using fast_hdbscan.PLSCAN.
 
     Parameters
     ----------
@@ -614,9 +614,6 @@ class PLSCANClusterer(Clusterer):
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
     show_progress_bar : bool, optional, deprecated
         Deprecated. Use verbose instead.
-    n_threads : Optional[int], optional
-        The number of threads to use for PLSCAN (default is -1). If -1, PLSCAN's
-        default thread handling is used. `None` is also passed through unchanged.
 
     Attributes
     ----------
@@ -626,8 +623,11 @@ class PLSCANClusterer(Clusterer):
         A dictionary representing the cluster tree.
     cluster_probabilities_ : List[np.ndarray]
         Membership probabilities for each returned layer.
-    cluster_cut_sizes_ : List[np.float32]
-        The minimum cluster size cut used to generate each returned layer.
+    cluster_persistence_scores_ : List[float]
+        Persistence scores for each returned layer.
+    plscan_min_cluster_sizes_ : Optional[np.ndarray]
+        The minimum cluster sizes explored by PLSCAN, when exposed by the
+        upstream implementation.
     """
 
     def __init__(
@@ -638,14 +638,12 @@ class PLSCANClusterer(Clusterer):
         max_layers: Optional[int] = None,
         verbose: Optional[bool] = None,
         show_progress_bar: Optional[bool] = None,
-        n_threads: Optional[int] = -1,
     ):
         super().__init__()
         self.min_clusters = min_clusters
         self.min_samples = min_samples
         self.base_min_cluster_size = base_min_cluster_size
         self.max_layers = max_layers
-        self.n_threads = n_threads
 
         _, self.verbose = handle_verbose_params(
             verbose=verbose, show_progress_bar=show_progress_bar, default_verbose=False
@@ -674,14 +672,19 @@ class PLSCANClusterer(Clusterer):
 
         self.plscan_ = PLSCAN(
             min_samples=self.min_samples,
-            min_cluster_size=self.base_min_cluster_size,
-            num_threads=None if self.n_threads == -1 else self.n_threads,
+            base_min_cluster_size=self.base_min_cluster_size,
+            max_layers=self.max_layers if self.max_layers is not None else 10,
+            verbose=verbose_output,
         )
         self.plscan_.fit(clusterable_vectors)
 
-        raw_cluster_layers = self.plscan_.cluster_layers()
+        raw_cluster_layers = zip(
+            self.plscan_.cluster_layers_,
+            self.plscan_.membership_strength_layers_,
+            self.plscan_.layer_persistence_scores_,
+        )
         filtered_cluster_layers = []
-        for cut_size, labels, probabilities in raw_cluster_layers:
+        for labels, probabilities, persistence_score in raw_cluster_layers:
             n_clusters_in_layer = labels.max() + 1
             if n_clusters_in_layer < self.min_clusters:
                 continue
@@ -689,7 +692,7 @@ class PLSCANClusterer(Clusterer):
                 print(
                     f"Layer {len(filtered_cluster_layers)} found {n_clusters_in_layer} clusters"
                 )
-            filtered_cluster_layers.append((cut_size, labels, probabilities))
+            filtered_cluster_layers.append((labels, probabilities, persistence_score))
             if (
                 self.max_layers is not None
                 and len(filtered_cluster_layers) >= self.max_layers
@@ -702,13 +705,16 @@ class PLSCANClusterer(Clusterer):
                 f"min_clusters={self.min_clusters}."
             )
 
-        cluster_label_layers = [labels for _, labels, _ in filtered_cluster_layers]
-        self.cluster_cut_sizes_ = [
-            cut_size for cut_size, _, _ in filtered_cluster_layers
-        ]
+        cluster_label_layers = [labels for labels, _, _ in filtered_cluster_layers]
         self.cluster_probabilities_ = [
-            probabilities for _, _, probabilities in filtered_cluster_layers
+            probabilities for _, probabilities, _ in filtered_cluster_layers
         ]
+        self.cluster_persistence_scores_ = [
+            persistence_score for _, _, persistence_score in filtered_cluster_layers
+        ]
+        self.plscan_min_cluster_sizes_ = getattr(
+            self.plscan_, "min_cluster_sizes_", None
+        )
         self.cluster_tree_ = build_cluster_tree(cluster_label_layers)
         self.cluster_layers_ = [
             layer_class(

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -685,10 +685,17 @@ class PLSCANClusterer(Clusterer):
         )
         filtered_cluster_layers = []
         for labels, probabilities, persistence_score in raw_cluster_layers:
+            # Normalize labels to be contiguous, preserving noise as -1
+            unique_labels, inverse = np.unique(labels, return_inverse=True)
+            if unique_labels.size > 0 and unique_labels[0] == -1:
+                labels = inverse - 1
+            else:
+                labels = inverse
+
             n_clusters_in_layer = labels.max() + 1
             if n_clusters_in_layer < self.min_clusters:
                 continue
-            if verbose_output:
+            if self.verbose:
                 print(
                     f"Layer {len(filtered_cluster_layers)} found {n_clusters_in_layer} clusters"
                 )

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -1,23 +1,21 @@
 from abc import ABC, abstractmethod
-import numpy as np
-import numba
-from fast_hdbscan.cluster_trees import (
-    mst_to_linkage_tree,
-    condense_tree,
-    extract_leaves,
-    get_cluster_label_vector,
-)
-from fast_hdbscan.boruvka import parallel_boruvka
-from fast_hdbscan.numba_kdtree import build_kdtree
-from sklearn.neighbors import KDTree
-from typing import List, Tuple, Dict, Type, Any, Optional
-from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
-from typing import List, Tuple, Dict, Type, Any, Optional, NewType
-from toponymy._utils import handle_verbose_params
+from typing import Any, Dict, List, NewType, Optional, Tuple, Type
 
+import numba
+import numpy as np
+from fast_hdbscan.boruvka import parallel_boruvka
+from fast_hdbscan.cluster_trees import condense_tree, extract_leaves
+from fast_hdbscan.numba_kdtree import build_kdtree
+from fast_plscan import PLSCAN
 from sklearn.cluster import KMeans
+from sklearn.neighbors import KDTree
+
+from toponymy._utils import handle_verbose_params
+from toponymy.cluster_layer import ClusterLayer, ClusterLayerText
 
 ClusterTree = NewType("ClusterTree", Dict[Tuple[int, int], List[Tuple[int, int]]])
+
+from fast_hdbscan.cluster_trees import get_cluster_label_vector
 
 
 @numba.njit(cache=True)
@@ -133,6 +131,8 @@ def build_raw_cluster_layers(
     List[np.ndarray]
         A list of numpy arrays, each representing cluster labels for a layer.
     """
+    from fast_hdbscan.cluster_trees import mst_to_linkage_tree
+
     n_samples = data.shape[0]
     cluster_layers: List[np.ndarray] = []
     min_cluster_size: np.signedinteger = np.intp(base_min_cluster_size)
@@ -570,6 +570,153 @@ class KMeansClusterer(Clusterer):
                 show_progress_bar=(
                     show_progress_bar if show_progress_bar is not None else False
                 ),
+                **layer_kwargs,
+            )
+            for i, labels in enumerate(cluster_label_layers)
+        ]
+        return self
+
+    def fit_predict(
+        self,
+        clusterable_vectors: np.ndarray,
+        embedding_vectors: np.ndarray,
+        layer_class: Type[ClusterLayer] = ClusterLayerText,
+        verbose: Optional[bool] = None,
+        show_progress_bar: Optional[bool] = None,
+        **layer_kwargs,
+    ) -> Tuple[List[ClusterLayer], Dict[Tuple[int, int], List[Tuple[int, int]]]]:
+        self.fit(
+            clusterable_vectors,
+            embedding_vectors,
+            layer_class=layer_class,
+            verbose=verbose,
+            show_progress_bar=show_progress_bar,
+            **layer_kwargs,
+        )
+        return self.cluster_layers_, self.cluster_tree_
+
+
+class PLSCANClusterer(Clusterer):
+    """
+    A class for clustering dense vector data in layers using fast_plscan.PLSCAN.
+
+    Parameters
+    ----------
+    min_clusters : int, optional
+        The minimum number of non-noise clusters to keep in a layer (default is 6).
+    min_samples : int, optional
+        The minimum number of samples used by PLSCAN (default is 5).
+    base_min_cluster_size : int, optional
+        The base minimum cluster size passed to PLSCAN (default is 10).
+    max_layers : Optional[int], optional
+        The maximum number of hierarchy layers to keep (default is None).
+    verbose : bool, optional
+        Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
+    show_progress_bar : bool, optional, deprecated
+        Deprecated. Use verbose instead.
+    n_threads : Optional[int], optional
+        The number of threads to use for PLSCAN (default is -1). If -1, PLSCAN's
+        default thread handling is used. `None` is also passed through unchanged.
+
+    Attributes
+    ----------
+    cluster_layers_ : List[ClusterLayer]
+        A list of the created cluster layers.
+    cluster_tree_ : Dict[Tuple[int, int], List[Tuple[int, int]]]
+        A dictionary representing the cluster tree.
+    cluster_probabilities_ : List[np.ndarray]
+        Membership probabilities for each returned layer.
+    cluster_cut_sizes_ : List[np.float32]
+        The minimum cluster size cut used to generate each returned layer.
+    """
+
+    def __init__(
+        self,
+        min_clusters: int = 6,
+        min_samples: int = 5,
+        base_min_cluster_size: int = 10,
+        max_layers: Optional[int] = None,
+        verbose: Optional[bool] = None,
+        show_progress_bar: Optional[bool] = None,
+        n_threads: Optional[int] = -1,
+    ):
+        super().__init__()
+        self.min_clusters = min_clusters
+        self.min_samples = min_samples
+        self.base_min_cluster_size = base_min_cluster_size
+        self.max_layers = max_layers
+        self.n_threads = n_threads
+
+        _, self.verbose = handle_verbose_params(
+            verbose=verbose, show_progress_bar=show_progress_bar, default_verbose=False
+        )
+
+    def fit(
+        self,
+        clusterable_vectors: np.ndarray,
+        embedding_vectors: np.ndarray,
+        layer_class: Type[ClusterLayer] = ClusterLayerText,
+        verbose: Optional[bool] = None,
+        show_progress_bar: Optional[bool] = None,
+        **layer_kwargs,
+    ) -> Clusterer:
+        show_progress_bar_val, verbose_output = handle_verbose_params(
+            verbose=verbose if verbose is not None else self.verbose,
+            show_progress_bar=show_progress_bar,
+            default_verbose=False,
+        )
+
+        # Normalize clustering inputs for the upstream PLSCAN engine; keep
+        # embedding_vectors untouched for Toponymy centroid construction.
+        clusterable_vectors = np.ascontiguousarray(
+            clusterable_vectors, dtype=np.float32
+        )
+
+        self.plscan_ = PLSCAN(
+            min_samples=self.min_samples,
+            min_cluster_size=self.base_min_cluster_size,
+            num_threads=None if self.n_threads == -1 else self.n_threads,
+        )
+        self.plscan_.fit(clusterable_vectors)
+
+        raw_cluster_layers = self.plscan_.cluster_layers()
+        filtered_cluster_layers = []
+        for cut_size, labels, probabilities in raw_cluster_layers:
+            n_clusters_in_layer = labels.max() + 1
+            if n_clusters_in_layer < self.min_clusters:
+                continue
+            if verbose_output:
+                print(
+                    f"Layer {len(filtered_cluster_layers)} found {n_clusters_in_layer} clusters"
+                )
+            filtered_cluster_layers.append((cut_size, labels, probabilities))
+            if (
+                self.max_layers is not None
+                and len(filtered_cluster_layers) >= self.max_layers
+            ):
+                break
+
+        if len(filtered_cluster_layers) == 0:
+            raise ValueError(
+                "Not enough clusters found in any PLSCAN layer: "
+                f"min_clusters={self.min_clusters}."
+            )
+
+        cluster_label_layers = [labels for _, labels, _ in filtered_cluster_layers]
+        self.cluster_cut_sizes_ = [
+            cut_size for cut_size, _, _ in filtered_cluster_layers
+        ]
+        self.cluster_probabilities_ = [
+            probabilities for _, _, probabilities in filtered_cluster_layers
+        ]
+        self.cluster_tree_ = build_cluster_tree(cluster_label_layers)
+        self.cluster_layers_ = [
+            layer_class(
+                labels,
+                centroids_from_labels(labels, embedding_vectors),
+                layer_id=i,
+                verbose=show_progress_bar_val,
+                show_progress_bar=show_progress_bar_val,
                 **layer_kwargs,
             )
             for i, labels in enumerate(cluster_label_layers)

--- a/toponymy/clustering.py
+++ b/toponymy/clustering.py
@@ -609,7 +609,7 @@ class PLSCANClusterer(Clusterer):
     base_min_cluster_size : int, optional
         The base minimum cluster size passed to PLSCAN (default is 10).
     max_layers : Optional[int], optional
-        The maximum number of hierarchy layers to keep (default is None).
+        The maximum number of hierarchy layers to keep (default is 10).
     verbose : bool, optional
         Whether to show progress bars and verbose output. If True, shows all output. If False, suppresses all output.
     show_progress_bar : bool, optional, deprecated
@@ -635,7 +635,7 @@ class PLSCANClusterer(Clusterer):
         min_clusters: int = 6,
         min_samples: int = 5,
         base_min_cluster_size: int = 10,
-        max_layers: Optional[int] = None,
+        max_layers: Optional[int] = 10,
         verbose: Optional[bool] = None,
         show_progress_bar: Optional[bool] = None,
     ):
@@ -673,7 +673,7 @@ class PLSCANClusterer(Clusterer):
         self.plscan_ = PLSCAN(
             min_samples=self.min_samples,
             base_min_cluster_size=self.base_min_cluster_size,
-            max_layers=self.max_layers if self.max_layers is not None else 10,
+            max_layers=self.max_layers,
             verbose=verbose_output,
         )
         self.plscan_.fit(clusterable_vectors)

--- a/toponymy/tests/test_clustering.py
+++ b/toponymy/tests/test_clustering.py
@@ -5,7 +5,13 @@ from sklearn.datasets import make_blobs
 from sklearn.metrics import adjusted_mutual_info_score, pairwise_distances
 
 from toponymy.cluster_layer import ClusterLayerText
-from toponymy.clustering import build_raw_cluster_layers, centroids_from_labels
+# fmt: off
+from toponymy.clustering import (KMeansClusterer, PLSCANClusterer,
+                                 ToponymyClusterer, _build_cluster_tree,
+                                 build_cluster_tree, build_raw_cluster_layers,
+                                 centroids_from_labels, create_cluster_layers)
+
+# fmt: on
 
 # Try to import EVoCClusterer - check if evoc is compatible with current fast_hdbscan
 try:
@@ -62,8 +68,6 @@ def test_centroids_from_labels_no_jit():
 
 
 def test_build_cluster_tree():
-    from toponymy.clustering import build_cluster_tree
-
     clusterable_data = np.vstack(
         [
             make_blobs(
@@ -106,8 +110,6 @@ def test_build_cluster_tree():
 
 
 def test_build_cluster_tree_no_jit():
-    from toponymy.clustering import _build_cluster_tree
-
     clusterable_data = np.vstack(
         [
             make_blobs(
@@ -157,8 +159,6 @@ def test_build_cluster_tree_no_jit():
 
 
 def test_clusterer_class():
-    from toponymy.clustering import ToponymyClusterer, create_cluster_layers
-
     clusterer = ToponymyClusterer(
         min_clusters=4,
         min_samples=5,
@@ -227,8 +227,6 @@ def test_clusterer_class():
 
 
 def test_kmeans_clusterer_class():
-    from toponymy.clustering import KMeansClusterer
-
     clusterer = KMeansClusterer(
         min_clusters=4,
         base_n_clusters=64,
@@ -261,14 +259,11 @@ def test_kmeans_clusterer_class():
 
 def test_plscan_clusterer_import():
     from toponymy import PLSCANClusterer as ImportedPLSCANClusterer
-    from toponymy.clustering import PLSCANClusterer
 
     assert ImportedPLSCANClusterer is PLSCANClusterer
 
 
 def test_plscan_clusterer_fit_returns_self():
-    from toponymy.clustering import PLSCANClusterer
-
     clusterer = PLSCANClusterer(
         min_clusters=4,
         min_samples=5,
@@ -292,7 +287,7 @@ def test_plscan_clusterer_fit_returns_self():
     )
 
     assert result is clusterer
-    assert len(clusterer.cluster_layers_) >= 1
+    assert len(clusterer.cluster_layers_) > 1
     assert len(clusterer.cluster_layers_) == len(clusterer.cluster_probabilities_)
     assert len(clusterer.cluster_layers_) == len(clusterer.cluster_persistence_scores_)
     np.testing.assert_array_equal(
@@ -321,8 +316,6 @@ def test_plscan_clusterer_fit_returns_self():
 
 
 def test_plscan_clusterer_fit_predict_returns_layers_and_tree():
-    from toponymy.clustering import PLSCANClusterer
-
     clusterable_data, _ = make_blobs(
         n_samples=2000,
         n_features=10,
@@ -367,8 +360,6 @@ def test_plscan_clusterer_fit_predict_returns_layers_and_tree():
 
 
 def test_plscan_clusterer_centroids_use_embedding_vectors():
-    from toponymy.clustering import PLSCANClusterer
-
     clusterable_data, _ = make_blobs(
         n_samples=1000,
         n_features=2,
@@ -398,8 +389,6 @@ def test_plscan_clusterer_centroids_use_embedding_vectors():
 
 
 def test_plscan_clusterer_raises_for_too_few_clusters():
-    from toponymy.clustering import PLSCANClusterer
-
     clusterable_data, _ = make_blobs(
         n_samples=300,
         n_features=2,
@@ -468,8 +457,6 @@ def test_evoc_clusterer_class():
 
 
 def test_max_layers_limit():
-    from toponymy.clustering import ToponymyClusterer
-
     """Test that max_layers parameter correctly limits the number of hierarchy levels."""
     # Create test data with many potential clusters
     np.random.seed(42)

--- a/toponymy/tests/test_clustering.py
+++ b/toponymy/tests/test_clustering.py
@@ -264,7 +264,6 @@ def test_plscan_clusterer_import():
     from toponymy.clustering import PLSCANClusterer
 
     assert ImportedPLSCANClusterer is PLSCANClusterer
-    assert PLSCANClusterer().n_threads == -1
 
 
 def test_plscan_clusterer_fit_returns_self():
@@ -274,7 +273,6 @@ def test_plscan_clusterer_fit_returns_self():
         min_clusters=4,
         min_samples=5,
         base_min_cluster_size=10,
-        n_threads=1,
     )
 
     clusterable_data, clusterable_labels = make_blobs(
@@ -296,7 +294,10 @@ def test_plscan_clusterer_fit_returns_self():
     assert result is clusterer
     assert len(clusterer.cluster_layers_) >= 1
     assert len(clusterer.cluster_layers_) == len(clusterer.cluster_probabilities_)
-    assert len(clusterer.cluster_layers_) == len(clusterer.cluster_cut_sizes_)
+    assert len(clusterer.cluster_layers_) == len(clusterer.cluster_persistence_scores_)
+    np.testing.assert_array_equal(
+        clusterer.plscan_min_cluster_sizes_, clusterer.plscan_.min_cluster_sizes_
+    )
     assert isinstance(clusterer.cluster_tree_, dict)
 
     for layer, probabilities in zip(
@@ -336,7 +337,6 @@ def test_plscan_clusterer_fit_predict_returns_layers_and_tree():
         min_clusters=4,
         min_samples=5,
         base_min_cluster_size=10,
-        n_threads=1,
     )
     layers_filtered, tree_filtered = clusterer_filtered.fit_predict(
         clusterable_vectors=clusterable_data,
@@ -355,7 +355,6 @@ def test_plscan_clusterer_fit_predict_returns_layers_and_tree():
         min_samples=5,
         base_min_cluster_size=10,
         max_layers=1,
-        n_threads=1,
     )
     layers_limited, tree_limited = clusterer_limited.fit_predict(
         clusterable_vectors=clusterable_data,
@@ -384,7 +383,6 @@ def test_plscan_clusterer_centroids_use_embedding_vectors():
         min_clusters=4,
         min_samples=5,
         base_min_cluster_size=10,
-        n_threads=1,
     )
     layers, _ = clusterer.fit_predict(
         clusterable_vectors=clusterable_data,
@@ -416,7 +414,6 @@ def test_plscan_clusterer_raises_for_too_few_clusters():
         min_clusters=50,
         min_samples=5,
         base_min_cluster_size=10,
-        n_threads=1,
     )
 
     with pytest.raises(

--- a/toponymy/tests/test_clustering.py
+++ b/toponymy/tests/test_clustering.py
@@ -1,25 +1,17 @@
-from toponymy.clustering import (
-    build_raw_cluster_layers,
-    build_cluster_tree,
-    centroids_from_labels,
-    create_cluster_layers,
-    _build_cluster_tree,
-    ToponymyClusterer,
-    KMeansClusterer,
-)
-from toponymy.cluster_layer import ClusterLayerText
-from sklearn.metrics import adjusted_mutual_info_score
 import numpy as np
 import pytest
-
-from sklearn.datasets import make_blobs
-from sklearn.metrics import pairwise_distances
 from scipy.optimize import linear_sum_assignment
+from sklearn.datasets import make_blobs
+from sklearn.metrics import adjusted_mutual_info_score, pairwise_distances
+
+from toponymy.cluster_layer import ClusterLayerText
+from toponymy.clustering import build_raw_cluster_layers, centroids_from_labels
 
 # Try to import EVoCClusterer - check if evoc is compatible with current fast_hdbscan
 try:
-    from toponymy.clustering import EVoCClusterer
     import fast_hdbscan
+
+    from toponymy.clustering import EVoCClusterer
 
     # evoc 0.3.1 is incompatible with fast_hdbscan >= 0.3.2 due to NumbaKDTree signature changes
     # Skip EVoC tests if we detect an incompatible version
@@ -70,6 +62,8 @@ def test_centroids_from_labels_no_jit():
 
 
 def test_build_cluster_tree():
+    from toponymy.clustering import build_cluster_tree
+
     clusterable_data = np.vstack(
         [
             make_blobs(
@@ -112,6 +106,8 @@ def test_build_cluster_tree():
 
 
 def test_build_cluster_tree_no_jit():
+    from toponymy.clustering import _build_cluster_tree
+
     clusterable_data = np.vstack(
         [
             make_blobs(
@@ -161,6 +157,8 @@ def test_build_cluster_tree_no_jit():
 
 
 def test_clusterer_class():
+    from toponymy.clustering import ToponymyClusterer, create_cluster_layers
+
     clusterer = ToponymyClusterer(
         min_clusters=4,
         min_samples=5,
@@ -229,6 +227,8 @@ def test_clusterer_class():
 
 
 def test_kmeans_clusterer_class():
+    from toponymy.clustering import KMeansClusterer
+
     clusterer = KMeansClusterer(
         min_clusters=4,
         base_n_clusters=64,
@@ -257,6 +257,176 @@ def test_kmeans_clusterer_class():
         >= (0.25 * (i + 1))
         for i in range(len(class_cluster_layers))
     )
+
+
+def test_plscan_clusterer_import():
+    from toponymy import PLSCANClusterer as ImportedPLSCANClusterer
+    from toponymy.clustering import PLSCANClusterer
+
+    assert ImportedPLSCANClusterer is PLSCANClusterer
+    assert PLSCANClusterer().n_threads == -1
+
+
+def test_plscan_clusterer_fit_returns_self():
+    from toponymy.clustering import PLSCANClusterer
+
+    clusterer = PLSCANClusterer(
+        min_clusters=4,
+        min_samples=5,
+        base_min_cluster_size=10,
+        n_threads=1,
+    )
+
+    clusterable_data, clusterable_labels = make_blobs(
+        n_samples=1000,
+        n_features=2,
+        centers=5,
+        center_box=(0.0, 1.0),
+        cluster_std=0.05,
+        random_state=0,
+    )
+    embedding_vectors = np.random.random_sample((1000, 256))
+
+    result = clusterer.fit(
+        clusterable_vectors=clusterable_data,
+        embedding_vectors=embedding_vectors,
+        layer_class=ClusterLayerText,
+    )
+
+    assert result is clusterer
+    assert len(clusterer.cluster_layers_) >= 1
+    assert len(clusterer.cluster_layers_) == len(clusterer.cluster_probabilities_)
+    assert len(clusterer.cluster_layers_) == len(clusterer.cluster_cut_sizes_)
+    assert isinstance(clusterer.cluster_tree_, dict)
+
+    for layer, probabilities in zip(
+        clusterer.cluster_layers_, clusterer.cluster_probabilities_
+    ):
+        assert layer.cluster_labels.shape == (1000,)
+        assert probabilities.shape == layer.cluster_labels.shape
+        assert layer.centroid_vectors.shape[0] == layer.cluster_labels.max() + 1
+        assert layer.centroid_vectors.shape[1] == embedding_vectors.shape[1]
+        assert np.all(probabilities >= 0.0)
+        assert np.all(probabilities <= 1.0)
+
+    final_labels = clusterer.cluster_layers_[-1].cluster_labels
+    assert (
+        adjusted_mutual_info_score(
+            final_labels[final_labels >= 0],
+            clusterable_labels[final_labels >= 0],
+        )
+        >= 0.9
+    )
+
+
+def test_plscan_clusterer_fit_predict_returns_layers_and_tree():
+    from toponymy.clustering import PLSCANClusterer
+
+    clusterable_data, _ = make_blobs(
+        n_samples=2000,
+        n_features=10,
+        centers=20,
+        center_box=(0.0, 1.0),
+        cluster_std=0.05,
+        random_state=42,
+    )
+    embedding_vectors = np.random.random_sample((2000, 64))
+
+    clusterer_filtered = PLSCANClusterer(
+        min_clusters=4,
+        min_samples=5,
+        base_min_cluster_size=10,
+        n_threads=1,
+    )
+    layers_filtered, tree_filtered = clusterer_filtered.fit_predict(
+        clusterable_vectors=clusterable_data,
+        embedding_vectors=embedding_vectors,
+        layer_class=ClusterLayerText,
+    )
+
+    assert layers_filtered is clusterer_filtered.cluster_layers_
+    assert tree_filtered is clusterer_filtered.cluster_tree_
+    assert len(layers_filtered) >= 1
+    assert isinstance(tree_filtered, dict)
+    assert layers_filtered[0].cluster_labels.max() + 1 >= 4
+
+    clusterer_limited = PLSCANClusterer(
+        min_clusters=2,
+        min_samples=5,
+        base_min_cluster_size=10,
+        max_layers=1,
+        n_threads=1,
+    )
+    layers_limited, tree_limited = clusterer_limited.fit_predict(
+        clusterable_vectors=clusterable_data,
+        embedding_vectors=embedding_vectors,
+        layer_class=ClusterLayerText,
+    )
+
+    assert len(layers_limited) == 1
+    assert isinstance(tree_limited, dict)
+
+
+def test_plscan_clusterer_centroids_use_embedding_vectors():
+    from toponymy.clustering import PLSCANClusterer
+
+    clusterable_data, _ = make_blobs(
+        n_samples=1000,
+        n_features=2,
+        centers=5,
+        center_box=(0.0, 1.0),
+        cluster_std=0.05,
+        random_state=7,
+    )
+    embedding_vectors = np.arange(1000 * 8, dtype=np.float64).reshape(1000, 8)
+
+    clusterer = PLSCANClusterer(
+        min_clusters=4,
+        min_samples=5,
+        base_min_cluster_size=10,
+        n_threads=1,
+    )
+    layers, _ = clusterer.fit_predict(
+        clusterable_vectors=clusterable_data,
+        embedding_vectors=embedding_vectors,
+        layer_class=ClusterLayerText,
+    )
+
+    layer = layers[0]
+    expected_centroids = centroids_from_labels(layer.cluster_labels, embedding_vectors)
+
+    np.testing.assert_allclose(layer.centroid_vectors, expected_centroids)
+    assert layer.centroid_vectors.shape[1] == embedding_vectors.shape[1]
+
+
+def test_plscan_clusterer_raises_for_too_few_clusters():
+    from toponymy.clustering import PLSCANClusterer
+
+    clusterable_data, _ = make_blobs(
+        n_samples=300,
+        n_features=2,
+        centers=3,
+        center_box=(0.0, 1.0),
+        cluster_std=0.05,
+        random_state=11,
+    )
+    embedding_vectors = np.random.random_sample((300, 16))
+
+    clusterer = PLSCANClusterer(
+        min_clusters=50,
+        min_samples=5,
+        base_min_cluster_size=10,
+        n_threads=1,
+    )
+
+    with pytest.raises(
+        ValueError, match="Not enough clusters found in any PLSCAN layer"
+    ):
+        clusterer.fit(
+            clusterable_vectors=clusterable_data,
+            embedding_vectors=embedding_vectors,
+            layer_class=ClusterLayerText,
+        )
 
 
 @pytest.mark.skipif(
@@ -301,6 +471,8 @@ def test_evoc_clusterer_class():
 
 
 def test_max_layers_limit():
+    from toponymy.clustering import ToponymyClusterer
+
     """Test that max_layers parameter correctly limits the number of hierarchy levels."""
     # Create test data with many potential clusters
     np.random.seed(42)


### PR DESCRIPTION
**Summary**
Addresses #149 by adding PLSCANClusterer as a thin wrapper around fast_plscan.PLSCAN.
This also exports PLSCANClusterer from toponymy and adds focused clustering tests for the new wrapper.

**Scope**
This PR only adds a new clusterer wrapper. It does not replace ToponymyClusterer or refactor the existing clustering architecture.

**Implementation notes**
Fits PLSCAN on clusterable_vectors
Computes Toponymy centroids from embedding_vectors
Reuses build_cluster_tree(...)
Preserves -1 labels as noise
Stores PLSCAN probabilities and cut sizes on the clusterer object

**Dependency impact**
Adds fast-plscan>=0.2.0,<0.3.
This may affect dependency resolution because fast-plscan introduces its own constraints, including around NumPy 2 and other transitive scientific dependencies.

**Verification**
isort --check-only toponymy/clustering.py toponymy/tests/test_clustering.py
black --check toponymy/clustering.py toponymy/tests/test_clustering.py
pytest -q toponymy/tests/test_clustering.py
pytest -q toponymy/tests/test_clustering.py -k plscan
Full pytest -q was not run locally due to a known unrelated missing llama_cpp dependency in toponymy/tests/test_llm_wrappers.py.