### PR TITLE
Resolve the prompt rendering in the LLM wrapper, not before it

### DIFF
--- a/doc/how_toponymy_works.ipynb
+++ b/doc/how_toponymy_works.ipynb
@@ -383,7 +383,7 @@
    "source": [
     "## Clustering\n",
     "\n",
-    "The first step in Toponymy's process is to first break the entire corpus down into clusters at multiple different resolution scales, starting with fine-grained clusters, and working up to find large-scale structures in the data. This is handled by the ``Clusterer`` within Toponymy, and you can read more about different clusterers, and options that can be passed in the tutorials on clusterers. For the purposes of this tutorial we will use standard options but we'll call the clusterer directly ourselves, and ensure the results get copied to where the ``Toponymy`` class will expect to find them. Note that there are some keyword arguments here (``show_progress_bar=topic_model.show_progress_bars``, ``exemplar_delimiters=topic_model.exemplar_delimiters``, and ``prompt_format=\"system_user\"``) that are derived from the Toponymy base class and are going to be passed through the set those properties for the instantiated layer classes produced by the clusterer. The ``prompt_format`` is set in the ``Toponymy.fit`` according to ``topic_model.llm_wrapper.supports_system_prompts``, and for the ``AzureAI`` that's true, so we will be using the separate system and user prompts (as opposed to a combined prompt that puts all the instructions in a single prompt)."
+    "The first step in Toponymy's process is to first break the entire corpus down into clusters at multiple different resolution scales, starting with fine-grained clusters, and working up to find large-scale structures in the data. This is handled by the ``Clusterer`` within Toponymy, and you can read more about different clusterers, and options that can be passed in the tutorials on clusterers. For the purposes of this tutorial we will use standard options but we'll call the clusterer directly ourselves, and ensure the results get copied to where the ``Toponymy`` class will expect to find them. Note that there are some keyword arguments here (``show_progress_bar=topic_model.show_progress_bars`` and ``exemplar_delimiters=topic_model.exemplar_delimiters``) that are derived from the Toponymy base class and are going to be passed through the set those properties for the instantiated layer classes produced by the clusterer."
    ]
   },
   {
@@ -408,8 +408,7 @@
     "    clusterable_vectors=clusterable_vectors, \n",
     "    embedding_vectors=embedding_vectors, \n",
     "    show_progress_bar=topic_model.show_progress_bars, \n",
-    "    exemplar_delimiters=topic_model.exemplar_delimiters, \n",
-    "    prompt_format=\"system_user\"\n",
+    "    exemplar_delimiters=topic_model.exemplar_delimiters\n",
     ")\n",
     "topic_model.cluster_layers_ = topic_model.clusterer.cluster_layers_\n",
     "topic_model.cluster_tree_ = topic_model.clusterer.cluster_tree_"

--- a/toponymy/_utils.py
+++ b/toponymy/_utils.py
@@ -5,6 +5,30 @@ import warnings
 from typing import Optional, Tuple
 
 
+def handle_deprecated_prompt_format(prompt_format: Optional[str]) -> None:
+    """
+    Warn if a caller still passes the retired ``prompt_format`` argument.
+
+    Prompts used to be rendered as either a combined string or a system/user pair,
+    chosen before the LLM wrapper was reached. Prompts now carry every rendering
+    and the wrapper selects one at call time, so the argument no longer does
+    anything.
+
+    Parameters
+    ----------
+    prompt_format : str, optional
+        The value the caller passed. ``None`` means the caller did not pass one.
+    """
+    if prompt_format is not None:
+        warnings.warn(
+            "prompt_format is deprecated and ignored, and will be removed in v2.0. "
+            "Prompts now carry every rendering and the LLM wrapper selects one at "
+            "call time.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
 def handle_verbose_params(
     verbose: Optional[bool] = None,
     verbose_legacy: Optional[bool] = None,

--- a/toponymy/cluster_layer.py
+++ b/toponymy/cluster_layer.py
@@ -39,7 +39,7 @@ from toponymy.prompt_construction import (
 )
 from tqdm.auto import tqdm
 import asyncio
-from toponymy._utils import handle_verbose_params
+from toponymy._utils import handle_deprecated_prompt_format, handle_verbose_params
 import warnings
 
 
@@ -94,11 +94,13 @@ class ClusterLayer(ABC):
         n_keyphrases: int = 24,
         n_subtopics: int = 24,
         exemplar_delimiters: List[str] = None,
-        prompt_format: str = "combined",
+        prompt_format: Optional[str] = None,
         prompt_template: Optional[Dict[str, Any]] = None,
         verbose: Optional[bool] = None,
         show_progress_bar: Optional[bool] = None,
     ):
+        handle_deprecated_prompt_format(prompt_format)
+
         self.cluster_labels = cluster_labels
         self.centroid_vectors = centroid_vectors
         self.layer_id = layer_id
@@ -108,7 +110,6 @@ class ClusterLayer(ABC):
         self.n_keyphrases = n_keyphrases
         self.n_subtopics = n_subtopics
         self.exemplar_delimiters = exemplar_delimiters
-        self.prompt_format = prompt_format
         self.prompt_template = prompt_template
         if exemplar_delimiters is None:
             self.exemplar_delimiters = ['    *"', '"\n']
@@ -146,7 +147,7 @@ class ClusterLayer(ABC):
         object_description: str,
         corpus_description: str,
         cluster_tree: Optional[dict] = None,
-        prompt_format: str = None,
+        prompt_format: Optional[str] = None,
         prompt_template: Optional[str] = None,
         all_topic_summaries: Optional[List[List[str]]] = None,
         all_topic_explanations: Optional[List[List[str]]] = None,
@@ -249,7 +250,6 @@ class ClusterLayer(ABC):
                 max_num_subtopics=self.n_subtopics,
                 exemplar_start_delimiter=self.exemplar_delimiters[0],
                 exemplar_end_delimiter=self.exemplar_delimiters[1],
-                prompt_format=self.prompt_format,
                 prompt_template=self.prompt_template,
             )
             for topic_indices in tqdm(
@@ -400,7 +400,7 @@ class ClusterLayerText(ClusterLayer):
         n_subtopics: int = 16,
         subtopic_diversify_alpha: float = 1.0,
         exemplar_delimiters: List[str] = None,
-        prompt_format: str = "combined",
+        prompt_format: Optional[str] = None,
         prompt_template: Optional[Dict[str, Any]] = None,
         verbose: Optional[bool] = None,
         show_progress_bar: Optional[bool] = None,
@@ -439,6 +439,8 @@ class ClusterLayerText(ClusterLayer):
         all_topic_summaries: Optional[List[List[str]]] = None,
         all_topic_explanations: Optional[List[List[str]]] = None,
     ) -> List[str | Dict[str, str]]:
+        handle_deprecated_prompt_format(prompt_format)
+
         summary_level = int(round(detail_level * (len(SUMMARY_KINDS) - 1)))
         summary_kind = SUMMARY_KINDS[summary_level]
 
@@ -459,9 +461,6 @@ class ClusterLayerText(ClusterLayer):
                 max_num_subtopics=self.n_subtopics,
                 exemplar_start_delimiter=self.exemplar_delimiters[0],
                 exemplar_end_delimiter=self.exemplar_delimiters[1],
-                prompt_format=(
-                    self.prompt_format if prompt_format is None else prompt_format
-                ),
                 prompt_template=(
                     self.prompt_template if prompt_template is None else prompt_template
                 ),
@@ -838,7 +837,7 @@ class ClusterLayerSummaryText(ClusterLayerText):
         n_subtopics: int = 16,
         subtopic_diversify_alpha: float = 1.0,
         exemplar_delimiters: List[str] = None,
-        prompt_format: str = "combined",
+        prompt_format: Optional[str] = None,
         prompt_template: Optional[str | Dict[str, Any]] = None,
         verbose: Optional[bool] = None,
         show_progress_bar: Optional[bool] = None,
@@ -872,11 +871,13 @@ class ClusterLayerSummaryText(ClusterLayerText):
         object_description: str,
         corpus_description: str,
         cluster_tree: Optional[dict] = None,
-        prompt_format: str = None,
+        prompt_format: Optional[str] = None,
         prompt_template: Optional[str] = None,
         all_topic_summaries: Optional[List[List[str]]] = None,
         all_topic_explanations: Optional[List[List[str]]] = None,
     ) -> List[str | Dict[str, str]]:
+        handle_deprecated_prompt_format(prompt_format)
+
         summary_level = int(round(detail_level * (len(SUMMARY_KINDS) - 1)))
         summary_kind = SUMMARY_KINDS[summary_level]
 
@@ -906,9 +907,6 @@ class ClusterLayerSummaryText(ClusterLayerText):
                 max_num_subtopics=self.n_subtopics,
                 exemplar_start_delimiter=self.exemplar_delimiters[0],
                 exemplar_end_delimiter=self.exemplar_delimiters[1],
-                prompt_format=(
-                    self.prompt_format if prompt_format is None else prompt_format
-                ),
                 prompt_template=(
                     self.prompt_template if prompt_template is None else prompt_template
                 ),

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -293,30 +293,87 @@ def llm_output_to_result(llm_output: str, regex: str) -> dict:
     return result
 
 
+def validate_prompt(prompt: Any, supports_system_prompts: bool) -> Dict[str, Any]:
+    """
+    Check that a prompt carries the rendering a wrapper is about to use.
+
+    Prompts are dictionaries built by :mod:`toponymy.prompt_construction`, carrying
+    every rendering of the same instruction: a "system"/"user" pair, and a "combined"
+    rendering that puts the whole instruction in a single message. A wrapper selects
+    between them at call time according to what its provider supports.
+
+    Parameters
+    ----------
+    prompt : Any
+        The prompt to check.
+    supports_system_prompts : bool
+        Whether the calling wrapper will use the system/user rendering (True) or the
+        combined rendering (False).
+
+    Returns
+    -------
+    prompt: Dict[str, Any]
+        The prompt, unchanged.
+
+    Raises
+    ------
+    InvalidLLMInputError
+        If the prompt is not a dictionary, or lacks the rendering that will be used.
+    """
+    if not isinstance(prompt, dict):
+        raise InvalidLLMInputError(
+            f"Prompt must be a dictionary of renderings, got {type(prompt)}. "
+            f"Prompts are built by toponymy.prompt_construction and carry a "
+            f"rendering under each of 'system', 'user' and 'combined'."
+        )
+
+    required = ("system", "user") if supports_system_prompts else ("combined",)
+    missing = [rendering for rendering in required if rendering not in prompt]
+    if missing:
+        raise InvalidLLMInputError(
+            f"Prompt is missing the {', '.join(missing)} rendering(s) this wrapper "
+            f"needs; it has {', '.join(sorted(prompt)) or 'no renderings'}."
+        )
+
+    return prompt
+
+
 class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     FAIL_FAST_EXCEPTIONS: tuple = ()
 
     @abstractmethod
-    def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+    def _call_llm(
+        self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+    ) -> str:
         """
-        Call the LLM with the given prompt and temperature.
+        Call the LLM with the combined rendering of the given prompt.
+
+        Implementations should send ``prompt["combined"]``, which carries the whole
+        instruction in a single message. This is the path taken when the wrapper
+        reports `supports_system_prompts` as False.
+
         This method should be implemented by subclasses.
         """
         pass
 
     @abstractmethod
     def _call_llm_with_system_prompt(
-        self, system_prompt: str, user_prompt: str, temperature: float, max_tokens: int
+        self, prompt: Dict[str, Any], temperature: float, max_tokens: int
     ) -> str:
         """
-        Call the LLM with a system prompt and user prompt.
+        Call the LLM with the system/user rendering of the given prompt.
+
+        Implementations should send ``prompt["system"]`` and ``prompt["user"]`` as a
+        system message and a user message. This is the path taken when the wrapper
+        reports `supports_system_prompts` as True.
+
         This method should be implemented by subclasses.
         """
         pass
 
     def _safe_call_llm(
         self,
-        prompt: str,
+        prompt: Dict[str, Any],
         temperature: float,
         max_tokens: int,
         routine: str | None = None,
@@ -352,20 +409,14 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     def _safe_call_llm_with_system_prompt(
         self,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: Dict[str, Any],
         temperature: float,
         max_tokens: int,
         routine: str | None = None,
     ) -> str:
-        prompt_payload = {
-            "system": system_prompt,
-            "user": user_prompt,
-        }
-
         try:
             raw_response = self._call_llm_with_system_prompt(
-                system_prompt, user_prompt, temperature, max_tokens
+                prompt, temperature, max_tokens
             )
 
             self._emit_debug_callback(
@@ -373,7 +424,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                     "event": "llm_call_success",
                     "prompt_type": "system",
                     "routine": routine,
-                    "prompt": prompt_payload,
+                    "prompt": prompt,
                     "raw_response": raw_response,
                 }
             )
@@ -385,7 +436,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                     "event": "llm_call_error",
                     "prompt_type": "system",
                     "routine": routine,
-                    "prompt": prompt_payload,
+                    "prompt": prompt,
                     "error": {
                         "type": type(e).__name__,
                         "message": str(e),
@@ -393,6 +444,37 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
                 }
             )
             self._handle_exception(e)
+
+    def _call_llm_for_prompt(
+        self,
+        prompt: Dict[str, Any],
+        temperature: float,
+        max_tokens: int,
+        routine: str | None = None,
+    ) -> str:
+        """
+        Send a prompt using whichever rendering this wrapper's provider supports.
+
+        This is the single point at which a prompt's renderings are resolved down to
+        one provider call, so that everything upstream of the wrapper can stay
+        provider agnostic.
+        """
+        prompt = validate_prompt(prompt, self.supports_system_prompts)
+
+        if self.supports_system_prompts:
+            return self._safe_call_llm_with_system_prompt(
+                prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                routine=routine,
+            )
+
+        return self._safe_call_llm(
+            prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            routine=routine,
+        )
 
     @staticmethod
     def _topic_name_error_callback(retry_state):
@@ -414,7 +496,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     )
     def generate_topic_name(
         self,
-        prompt: Union[str, Dict[str, str]],
+        prompt: Dict[str, Any],
         temperature: float = 0.4,
         topic_extraction_function=lambda x: x["topic_name"],
         get_topic_name_regex=GET_TOPIC_NAME_REGEX,
@@ -423,26 +505,12 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         if max_tokens is None:
             max_tokens = getattr(self, "max_tokens_topic_name", 128)
 
-        if isinstance(prompt, str):
-            topic_name_info_raw = self._safe_call_llm(
-                prompt,
-                temperature,
-                max_tokens=max_tokens,
-                routine="generate_topic_name",
-            )
-        elif isinstance(prompt, dict) and self.supports_system_prompts:
-            topic_name_info_raw = self._safe_call_llm_with_system_prompt(
-                system_prompt=prompt["system"],
-                user_prompt=prompt["user"],
-                temperature=temperature,
-                max_tokens=max_tokens,
-                routine="generate_topic_name",
-            )
-        else:
-            warn(f"Prompt must be a string or a dictionary, got {type(prompt)}")
-            raise InvalidLLMInputError(
-                f"Prompt must be a string or a dictionary, got {type(prompt)}"
-            )
+        topic_name_info_raw = self._call_llm_for_prompt(
+            prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            routine="generate_topic_name",
+        )
 
         topic_name_info = llm_output_to_result(
             topic_name_info_raw, get_topic_name_regex
@@ -476,7 +544,7 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
     )
     def generate_topic_cluster_names(
         self,
-        prompt: Union[str, Dict[str, str]],
+        prompt: Dict[str, Any],
         old_names: List[str],
         temperature: float = 0.4,
         extract_topic_names_function=default_extract_topic_names,
@@ -486,25 +554,12 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         if max_tokens is None:
             max_tokens = getattr(self, "max_tokens_cluster_names", 1024)
 
-        if isinstance(prompt, str):
-            topic_name_info_raw = self._safe_call_llm(
-                prompt,
-                temperature,
-                max_tokens=max_tokens,
-                routine="generate_topic_cluster_names",
-            )
-        elif isinstance(prompt, dict) and self.supports_system_prompts:
-            topic_name_info_raw = self._safe_call_llm_with_system_prompt(
-                system_prompt=prompt["system"],
-                user_prompt=prompt["user"],
-                temperature=temperature,
-                max_tokens=max_tokens,
-                routine="generate_topic_cluster_names",
-            )
-        else:
-            raise InvalidLLMInputError(
-                f"Prompt must be a string or a dictionary, got {type(prompt)}"
-            )
+        topic_name_info_raw = self._call_llm_for_prompt(
+            prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            routine="generate_topic_cluster_names",
+        )
 
         topic_name_info = llm_output_to_result(
             topic_name_info_raw, GET_TOPIC_CLUSTER_NAMES_REGEX
@@ -598,14 +653,13 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         try:
             if system_prompt is None:
                 response = self._call_llm(
-                    prompt,
+                    {"combined": prompt},
                     temperature=0.4,
                     max_tokens=128,
                 )
             else:
                 response = self._call_llm_with_system_prompt(
-                    system_prompt,
-                    prompt,
+                    {"system": system_prompt, "user": prompt},
                     temperature=0.4,
                     max_tokens=128,
                 )
@@ -624,11 +678,15 @@ class LLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_single_llm(
-        self, prompt: str, temperature: float, max_tokens: int
+        self, prompt: Dict[str, Any], temperature: float, max_tokens: int
     ) -> str:
         """
-        Execute a single provider request for one user prompt and return the raw
-        text result from the model.
+        Execute a single provider request for the combined rendering of one prompt
+        and return the raw text result from the model.
+
+        Implementations should send ``prompt["combined"]``, which carries the whole
+        instruction in a single message. This is the path taken when the wrapper
+        reports `supports_system_prompts` as False.
 
         Subclasses should implement this method when their provider interaction
         follows the common pattern of issuing one request per prompt.
@@ -660,14 +718,17 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_single_llm_with_system(
         self,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: Dict[str, Any],
         temperature: float,
         max_tokens: int,
     ) -> str:
         """
-        Execute a single provider request for one system prompt + user prompt pair
+        Execute a single provider request for the system/user rendering of one prompt
         and return the raw text result from the model.
+
+        Implementations should send ``prompt["system"]`` and ``prompt["user"]`` as a
+        system message and a user message. This is the path taken when the wrapper
+        reports `supports_system_prompts` as True.
 
         Subclasses should implement this method when the provider supports system
         prompts and uses a one-request-per-prompt execution model.
@@ -695,13 +756,14 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_llm_batch(
         self,
-        prompts: List[str],
+        prompts: List[Dict[str, Any]],
         temperature: float,
         max_tokens: int,
         routine: str | None = None,
     ) -> List[CallResult[str]]:
         """
-        Process a batch of prompts and return one CallResult per prompt.
+        Process a batch of prompts using their combined rendering, and return one
+        CallResult per prompt.
 
         The default implementation wraps `_call_single_llm` with retry and error
         handling via `_safe_call_with_retry_result` and runs all prompts concurrently
@@ -739,9 +801,9 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         tasks = [
             self._safe_call_with_retry_result(
                 self._call_single_llm,
-                prompt,
-                temperature,
-                max_tokens,
+                prompt=prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
                 routine=routine,
             )
             for prompt in prompts
@@ -750,36 +812,35 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def _call_llm_with_system_prompt_batch(
         self,
-        system_prompts: List[str],
-        user_prompts: List[str],
+        prompts: List[Dict[str, Any]],
         temperature: float,
         max_tokens: int,
         routine: str | None = None,
     ) -> List[CallResult[str]]:
         """
-        Process a batch of system prompt + user prompt pairs and return one CallResult
-        per pair.
+        Process a batch of prompts using their system/user rendering, and return one
+        CallResult per prompt.
 
         The default implementation wraps `_call_single_llm_with_system` with retry and
-        error handling via `_safe_call_with_retry_result` and executes all prompt pairs
+        error handling via `_safe_call_with_retry_result` and executes all prompts
         concurrently using `asyncio.gather`.
 
         This produces the standard async behavior used by most wrappers:
 
-            - retryable errors are retried per prompt pair
+            - retryable errors are retried per prompt
             - fail-fast errors abort the entire batch/layer
             - exhausted retryable errors return CallResult(error=...)
             - successful calls return CallResult(value=<text>)
 
         Subclasses normally should NOT override this method if their provider model is
-        "one async request per prompt pair". Instead, implement
+        "one async request per prompt". Instead, implement
         `_call_single_llm_with_system` and inherit this default batching behavior.
 
         Override this method when the provider uses a fundamentally different batch
         model than concurrent single-call execution, such as:
 
             - provider-managed batch job APIs
-            - bulk endpoints accepting multiple prompt pairs in one request
+            - bulk endpoints accepting multiple prompts in one request
             - server-side batching that must be coordinated as a unit
 
         In the current architecture, such providers may still inherit from
@@ -790,31 +851,51 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
         Note:
             Some legacy wrapper implementations override `_call_llm_with_system_prompt_batch`
-            with a "one async request per prompt pair" model. Those implementations remain
+            with a "one async request per prompt" model. Those implementations remain
             supported and will take precedence over this default method.
         """
-        if len(system_prompts) != len(user_prompts):
-            raise ValueError(
-                "Number of system prompts must match number of user prompts"
-            )
-
         tasks = [
             self._safe_call_with_retry_result(
                 self._call_single_llm_with_system,
-                sys_prompt,
-                user_prompt,
-                temperature,
-                max_tokens,
+                prompt=prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
                 routine=routine,
             )
-            for sys_prompt, user_prompt in zip(system_prompts, user_prompts)
+            for prompt in prompts
         ]
 
         return await asyncio.gather(*tasks)
 
+    async def _call_llm_batch_for_prompts(
+        self,
+        prompts: List[Dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+    ) -> List[CallResult[str]]:
+        """
+        Send a batch of prompts using whichever rendering this wrapper's provider
+        supports.
+
+        This is the single point at which a prompt's renderings are resolved down to
+        one provider call, so that everything upstream of the wrapper can stay
+        provider agnostic.
+        """
+        supports_system_prompts = self.supports_system_prompts
+        prompts = [
+            validate_prompt(prompt, supports_system_prompts) for prompt in prompts
+        ]
+
+        if supports_system_prompts:
+            return await self._call_llm_with_system_prompt_batch(
+                prompts, temperature, max_tokens=max_tokens
+            )
+
+        return await self._call_llm_batch(prompts, temperature, max_tokens=max_tokens)
+
     async def generate_topic_names(
         self,
-        prompts: List[Union[str, Dict[str, str]]],
+        prompts: List[Dict[str, Any]],
         temperature: float = 0.4,
         extract_topic_name_function=lambda x: x["topic_name"],
         get_topic_name_regex=GET_TOPIC_NAME_REGEX,
@@ -831,21 +912,9 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         if not prompts:
             return []
 
-        # Check the first prompt to determine type
-        if isinstance(prompts[0], str):
-            responses = await self._call_llm_batch(
-                prompts, temperature, max_tokens=max_tokens
-            )
-        elif isinstance(prompts[0], dict) and self.supports_system_prompts:
-            system_prompts = [p["system"] for p in prompts]
-            user_prompts = [p["user"] for p in prompts]
-            responses = await self._call_llm_with_system_prompt_batch(
-                system_prompts, user_prompts, temperature, max_tokens=max_tokens
-            )
-        else:
-            raise InvalidLLMInputError(
-                f"Prompts must be strings or dictionaries, got {type(prompts[0])}"
-            )
+        responses = await self._call_llm_batch_for_prompts(
+            prompts, temperature, max_tokens=max_tokens
+        )
 
         # Parse responses
         results = []
@@ -886,7 +955,7 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
     async def generate_topic_cluster_names(
         self,
-        prompts: List[Union[str, Dict[str, str]]],
+        prompts: List[Dict[str, Any]],
         old_names_list: List[List[str]],
         temperature: float = 0.4,
         extract_topic_names_function=default_extract_topic_names,
@@ -906,21 +975,9 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
         if not prompts:
             return []
 
-        # Check the first prompt to determine type
-        if isinstance(prompts[0], str):
-            responses = await self._call_llm_batch(
-                prompts, temperature, max_tokens=max_tokens
-            )
-        elif isinstance(prompts[0], dict) and self.supports_system_prompts:
-            system_prompts = [prompt["system"] for prompt in prompts]
-            user_prompts = [prompt["user"] for prompt in prompts]
-            responses = await self._call_llm_with_system_prompt_batch(
-                system_prompts, user_prompts, temperature, max_tokens=max_tokens
-            )
-        else:
-            raise InvalidLLMInputError(
-                f"Prompts must be strings or dictionaries, got {type(prompts[0])}"
-            )
+        responses = await self._call_llm_batch_for_prompts(
+            prompts, temperature, max_tokens=max_tokens
+        )
 
         # Parse responses
         results = []
@@ -1045,29 +1102,29 @@ class AsyncLLMWrapper(DebugCallbackMixin, LLMErrorHandlingMixin, ABC):
 
         try:
             if system_prompt is None:
+                probe_prompt = {"combined": prompt}
                 try:
                     response = await self._call_single_llm(
-                        prompt, temperature=0.4, max_tokens=128
+                        probe_prompt, temperature=0.4, max_tokens=128
                     )
                 except NotImplementedError:
                     responses = await self._call_llm_batch(
-                        [prompt], temperature=0.4, max_tokens=128
+                        [probe_prompt], temperature=0.4, max_tokens=128
                     )
                     if not responses:
                         raise RuntimeError("Connectivity probe returned no responses")
                     response = responses[0]
             else:
+                probe_prompt = {"system": system_prompt, "user": prompt}
                 try:
                     response = await self._call_single_llm_with_system(
-                        system_prompt,
-                        prompt,
+                        probe_prompt,
                         temperature=0.4,
                         max_tokens=128,
                     )
                 except NotImplementedError:
                     responses = await self._call_llm_with_system_prompt_batch(
-                        [system_prompt],
-                        [prompt],
+                        [probe_prompt],
                         temperature=0.4,
                         max_tokens=128,
                     )
@@ -1112,11 +1169,13 @@ class FailedImportLLMWrapper(LLMWrapper):
     def __init__(self, *args, **kwds):
         raise LLMWrapperImportError(self._import_error_message())
 
-    def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+    def _call_llm(
+        self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+    ) -> str:
         raise LLMWrapperImportError(self._import_error_message())
 
     def _call_llm_with_system_prompt(
-        self, system_prompt: str, user_prompt: str, temperature: float, max_tokens: int
+        self, prompt: Dict[str, Any], temperature: float, max_tokens: int
     ) -> str:
         raise LLMWrapperImportError(self._import_error_message())
 
@@ -1136,14 +1195,13 @@ class FailedImportAsyncLLMWrapper(AsyncLLMWrapper):
         raise LLMWrapperImportError(self._import_error_message())
 
     async def _call_llm_batch(
-        self, prompts: List[str], temperature: float, max_tokens: int
+        self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
     ) -> List[str]:
         raise LLMWrapperImportError(self._import_error_message())
 
     async def _call_llm_with_system_prompt_batch(
         self,
-        system_prompt: str,
-        user_prompts: List[str],
+        prompts: List[Dict[str, Any]],
         temperature: float,
         max_tokens: int,
     ) -> List[str]:
@@ -1424,7 +1482,9 @@ try:
             )
             return response.choices[0].message.content
 
-        def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+        def _call_llm(
+            self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+        ) -> str:
             effective_temperature = (
                 self.temperature_override
                 if self.temperature_override is not None
@@ -1432,7 +1492,10 @@ try:
             )
             return self._completion_with_messages(
                 messages=[
-                    {"role": "user", "content": prompt + self.extra_prompting},
+                    {
+                        "role": "user",
+                        "content": prompt["combined"] + self.extra_prompting,
+                    },
                 ],
                 temperature=effective_temperature,
                 max_tokens=max_tokens,
@@ -1440,11 +1503,12 @@ try:
 
         def _call_llm_with_system_prompt(
             self,
-            system_prompt: str,
-            user_prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
+            system_prompt = prompt["system"]
+            user_prompt = prompt["user"]
             effective_temperature = (
                 self.temperature_override
                 if self.temperature_override is not None
@@ -1713,7 +1777,7 @@ try:
 
         async def _call_single_llm(
             self,
-            prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
@@ -1723,18 +1787,24 @@ try:
                 else temperature
             )
             return await self._acompletion_with_messages(
-                messages=[{"role": "user", "content": prompt + self.extra_prompting}],
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt["combined"] + self.extra_prompting,
+                    }
+                ],
                 temperature=effective_temperature,
                 max_tokens=max_tokens,
             )
 
         async def _call_single_llm_with_system(
             self,
-            system_prompt: str,
-            user_prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
+            system_prompt = prompt["system"]
+            user_prompt = prompt["user"]
             effective_temperature = (
                 self.temperature_override
                 if self.temperature_override is not None
@@ -2483,9 +2553,11 @@ try:
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
 
-        def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+        def _call_llm(
+            self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+        ) -> str:
             response = self.llm(
-                prompt + self.extra_prompting,
+                prompt["combined"] + self.extra_prompting,
                 max_new_tokens=max_tokens,
                 temperature=temperature,
             )
@@ -2494,8 +2566,7 @@ try:
 
         def _call_llm_with_system_prompt(
             self,
-            system_prompt: str,
-            user_prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
@@ -2569,9 +2640,16 @@ try:
                 "\n\n" + llm_specific_instructions if llm_specific_instructions else ""
             )
 
-        def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+        def _call_llm(
+            self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+        ) -> str:
             response = self.llm(
-                [{"role": "user", "content": prompt + self.extra_prompting}],
+                [
+                    {
+                        "role": "user",
+                        "content": prompt["combined"] + self.extra_prompting,
+                    }
+                ],
                 return_full_text=False,
                 max_new_tokens=max_tokens,
                 temperature=temperature,
@@ -2583,15 +2661,17 @@ try:
 
         def _call_llm_with_system_prompt(
             self,
-            system_prompt: str,
-            user_prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
             response = self.llm(
                 [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt + self.extra_prompting},
+                    {"role": "system", "content": prompt["system"]},
+                    {
+                        "role": "user",
+                        "content": prompt["user"] + self.extra_prompting,
+                    },
                 ],
                 return_full_text=False,
                 max_new_tokens=max_tokens,
@@ -2624,12 +2704,17 @@ try:
             self.max_concurrent_requests = max_concurrent_requests
 
         async def _call_llm_batch(
-            self, prompts: List[str], temperature: float, max_tokens: int
+            self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
         ) -> List[str]:
             responses = []
             for prompt in prompts:
                 response = self.llm(
-                    [{"role": "user", "content": prompt + self.extra_prompting}],
+                    [
+                        {
+                            "role": "user",
+                            "content": prompt["combined"] + self.extra_prompting,
+                        }
+                    ],
                     return_full_text=False,
                     max_new_tokens=max_tokens,
                     temperature=temperature,
@@ -2641,17 +2726,19 @@ try:
 
         async def _call_llm_with_system_prompt_batch(
             self,
-            system_prompts: List[str],
-            user_prompts: List[str],
+            prompts: List[Dict[str, Any]],
             temperature: float,
             max_tokens: int,
         ) -> List[str]:
             responses = []
-            for system_prompt, user_prompt in zip(system_prompts, user_prompts):
+            for prompt in prompts:
                 response = self.llm(
                     [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt + self.extra_prompting},
+                        {"role": "system", "content": prompt["system"]},
+                        {
+                            "role": "user",
+                            "content": prompt["user"] + self.extra_prompting,
+                        },
                     ],
                     return_full_text=False,
                     max_new_tokens=max_tokens,
@@ -2736,11 +2823,15 @@ try:
             """
             self.llm = vllm.LLM(model=self.model, **self.kwargs)
 
-        def _call_llm(self, prompt: str, temperature: float, max_tokens: int) -> str:
+        def _call_llm(
+            self, prompt: Dict[str, Any], temperature: float, max_tokens: int
+        ) -> str:
             sampling_params = vllm.SamplingParams(
                 temperature=temperature, max_tokens=max_tokens
             )
-            message = [{"role": "user", "content": prompt + self.extra_prompting}]
+            message = [
+                {"role": "user", "content": prompt["combined"] + self.extra_prompting}
+            ]
             try:
                 outputs = self.llm.chat(message, sampling_params=sampling_params)
             except vllm.v1.engine.exceptions.EngineDeadError:
@@ -2752,8 +2843,7 @@ try:
 
         def _call_llm_with_system_prompt(
             self,
-            system_prompt: str,
-            user_prompt: str,
+            prompt: Dict[str, Any],
             temperature: float,
             max_tokens: int,
         ) -> str:
@@ -2761,8 +2851,8 @@ try:
                 temperature=temperature, max_tokens=max_tokens
             )
             messages = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt + self.extra_prompting},
+                {"role": "system", "content": prompt["system"]},
+                {"role": "user", "content": prompt["user"] + self.extra_prompting},
             ]
 
             try:
@@ -2799,10 +2889,15 @@ try:
             self.llm = vllm.LLM(model=self.model, **self.kwargs)
 
         async def _call_llm_batch(
-            self, prompts: List[str], temperature: float, max_tokens: int
+            self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
         ) -> List[str]:
             messages = [
-                [{"role": "user", "content": prompt + self.extra_prompting}]
+                [
+                    {
+                        "role": "user",
+                        "content": prompt["combined"] + self.extra_prompting,
+                    }
+                ]
                 for prompt in prompts
             ]
             sampling_params = vllm.SamplingParams(
@@ -2823,17 +2918,19 @@ try:
 
         async def _call_llm_with_system_prompt_batch(
             self,
-            system_prompts: List[str],
-            user_prompts: List[str],
+            prompts: List[Dict[str, Any]],
             temperature: float,
             max_tokens: int,
         ) -> List[str]:
             messages = []
-            for system_prompt, user_prompt in zip(system_prompts, user_prompts):
+            for prompt in prompts:
                 messages.append(
                     [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt + self.extra_prompting},
+                        {"role": "system", "content": prompt["system"]},
+                        {
+                            "role": "user",
+                            "content": prompt["user"] + self.extra_prompting,
+                        },
                     ]
                 )
             sampling_params = vllm.SamplingParams(
@@ -2940,7 +3037,7 @@ try:
             self.timeout = timeout
 
         async def _call_llm_batch(
-            self, prompts: List[str], temperature: float, max_tokens: int
+            self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
         ) -> List[str]:
             """
             Submit a batch job and wait for completion.
@@ -2958,7 +3055,8 @@ try:
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": prompt + self.extra_prompting,
+                                    "content": prompt["combined"]
+                                    + self.extra_prompting,
                                 }
                             ],
                             "temperature": temperature,
@@ -2978,24 +3076,16 @@ try:
 
         async def _call_llm_with_system_prompt_batch(
             self,
-            system_prompts: List[str],
-            user_prompts: List[str],
+            prompts: List[Dict[str, Any]],
             temperature: float,
             max_tokens: int,
         ) -> List[str]:
             """
             Submit a batch job with system prompts and wait for completion.
             """
-            if len(system_prompts) != len(user_prompts):
-                raise ValueError(
-                    "Number of system prompts must match number of user prompts"
-                )
-
             # Create batch requests
             requests = []
-            for i, (sys_prompt, user_prompt) in enumerate(
-                zip(system_prompts, user_prompts)
-            ):
+            for i, prompt in enumerate(prompts):
                 requests.append(
                     {
                         "custom_id": str(i),
@@ -3003,10 +3093,10 @@ try:
                             "model": self.model,
                             "max_tokens": max_tokens,
                             "messages": [
-                                {"role": "system", "content": sys_prompt},
+                                {"role": "system", "content": prompt["system"]},
                                 {
                                     "role": "user",
-                                    "content": user_prompt + self.extra_prompting,
+                                    "content": prompt["user"] + self.extra_prompting,
                                 },
                             ],
                             "temperature": temperature,
@@ -3219,7 +3309,7 @@ try:
             self.timeout = timeout
 
         async def _call_llm_batch(
-            self, prompts: List[str], temperature: float, max_tokens: int
+            self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
         ) -> List[str]:
             """
             Submit a batch job and wait for completion.
@@ -3237,7 +3327,8 @@ try:
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": prompt + self.extra_prompting,
+                                    "content": prompt["combined"]
+                                    + self.extra_prompting,
                                 }
                             ],
                             "temperature": temperature,
@@ -3257,35 +3348,27 @@ try:
 
         async def _call_llm_with_system_prompt_batch(
             self,
-            system_prompts: List[str],
-            user_prompts: List[str],
+            prompts: List[Dict[str, Any]],
             temperature: float,
             max_tokens: int,
         ) -> List[str]:
             """
             Submit a batch job with system prompts and wait for completion.
             """
-            if len(system_prompts) != len(user_prompts):
-                raise ValueError(
-                    "Number of system prompts must match number of user prompts"
-                )
-
             # Create batch requests
             requests = []
-            for i, (sys_prompt, user_prompt) in enumerate(
-                zip(system_prompts, user_prompts)
-            ):
+            for i, prompt in enumerate(prompts):
                 requests.append(
                     {
                         "custom_id": str(i),
                         "params": {
                             "model": self.model,
                             "max_tokens": max_tokens,
-                            "system": sys_prompt,
+                            "system": prompt["system"],
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": user_prompt + self.extra_prompting,
+                                    "content": prompt["user"] + self.extra_prompting,
                                 },
                             ],
                             "temperature": temperature,
@@ -4124,7 +4207,7 @@ try:
             self._warn_if_debug_callback_unsupported()
 
         async def _call_llm_batch(
-            self, prompts: List[str], temperature: float, max_tokens: int
+            self, prompts: List[Dict[str, Any]], temperature: float, max_tokens: int
         ) -> List[str]:
             """
             Submit a batch job and wait for completion.
@@ -4142,7 +4225,8 @@ try:
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": prompt + self.extra_prompting,
+                                    "content": prompt["combined"]
+                                    + self.extra_prompting,
                                 }
                             ],
                             "temperature": temperature,
@@ -4162,24 +4246,16 @@ try:
 
         async def _call_llm_with_system_prompt_batch(
             self,
-            system_prompts: List[str],
-            user_prompts: List[str],
+            prompts: List[Dict[str, Any]],
             temperature: float,
             max_tokens: int,
         ) -> List[str]:
             """
             Submit a batch job with system prompts and wait for completion.
             """
-            if len(system_prompts) != len(user_prompts):
-                raise ValueError(
-                    "Number of system prompts must match number of user prompts"
-                )
-
             # Create batch requests
             requests = []
-            for i, (sys_prompt, user_prompt) in enumerate(
-                zip(system_prompts, user_prompts)
-            ):
+            for i, prompt in enumerate(prompts):
                 requests.append(
                     {
                         "custom_id": str(i),
@@ -4187,10 +4263,10 @@ try:
                             "model": self.model,
                             "max_tokens": max_tokens,
                             "messages": [
-                                {"role": "system", "content": sys_prompt},
+                                {"role": "system", "content": prompt["system"]},
                                 {
                                     "role": "user",
-                                    "content": user_prompt + self.extra_prompting,
+                                    "content": prompt["user"] + self.extra_prompting,
                                 },
                             ],
                             "temperature": temperature,

--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -3499,6 +3499,7 @@ except:
         def __init__(self, *args, **kwds):
             super().__init__(*args, **kwds)
 
+
 # Ollama
 def OllamaNamer(
     model: str = "llama3.2",

--- a/toponymy/prompt_construction.py
+++ b/toponymy/prompt_construction.py
@@ -6,10 +6,49 @@ from collections import defaultdict
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.metrics import pairwise_distances
 from toponymy.embedding_wrappers import TextEmbedderProtocol
+from toponymy._utils import handle_deprecated_prompt_format
 
 from typing import List, Optional, Any, Tuple, Union, Dict
 
 COSINE_DISTANCE_EPSILON = 1e-6
+
+# Every rendering of a prompt that an LLM wrapper might ask for. Prompts carry all
+# of them; the wrapper selects one at call time based on what its provider supports.
+PROMPT_RENDERINGS = ("system", "user", "combined")
+
+
+def render_prompt(
+    template_set: Dict[str, Any], render_params: Dict[str, Any]
+) -> Dict[str, str]:
+    """
+    Render every variant of a prompt that an LLM wrapper might need.
+
+    Parameters
+    ----------
+    template_set : Dict[str, Any]
+        A section of a prompt template set (for example ``PROMPT_TEMPLATES["layer"]``),
+        providing a jinja2 template for each entry of ``PROMPT_RENDERINGS``.
+    render_params : Dict[str, Any]
+        The parameters to render the templates with.
+
+    Returns
+    -------
+    prompt: Dict[str, str]
+        The rendered prompt, keyed by rendering.
+    """
+    missing = [key for key in PROMPT_RENDERINGS if key not in template_set]
+    if missing:
+        raise KeyError(
+            f"Prompt template set is missing the {', '.join(missing)} "
+            f"template(s). Prompt templates must provide all of "
+            f"{', '.join(PROMPT_RENDERINGS)} so that an LLM wrapper can select "
+            f"the rendering its provider supports."
+        )
+
+    return {
+        rendering: template_set[rendering].render(**render_params)
+        for rendering in PROMPT_RENDERINGS
+    }
 
 
 def find_threshold_for_max_cluster_size(
@@ -124,9 +163,9 @@ def distinguish_topic_names_prompt(
     max_num_exemplars: int = 128,
     exemplar_start_delimiter: str = '    * "',
     exemplar_end_delimiter: str = '"\n',
-    prompt_format: str = "combined",
+    prompt_format: Optional[str] = None,
     prompt_template: Optional[Dict[str, Any]] = None,
-) -> Union[str, Dict[str, str]]:
+) -> Dict[str, str]:
     """
     Construct a prompt for distinguishing between multiple topics.
 
@@ -163,17 +202,21 @@ def distinguish_topic_names_prompt(
     exemplar_end_delimiter : str, optional
         End delimiter for exemplar texts, by default "\"\n"
     prompt_format : str, optional
-        Format of the prompt, either "combined" or "system_user" to use a separate
-        system prompt, by default "combined".
+        Deprecated and ignored. Prompts now carry every rendering and the LLM
+        wrapper selects one at call time.
     prompt_template : Optional[str], optional
         Custom prompt template to use, by default None. If provided, this will override
-        the default prompt template.
+        the default prompt template. Custom templates must provide a template for each
+        of "system", "user" and "combined".
 
     Returns
     -------
-    prompt: str or dict
-        LLM Prompt for distinguishing between the topics.
+    prompt: dict
+        LLM Prompt for distinguishing between the topics, keyed by rendering
+        ("system", "user" and "combined").
     """
+    handle_deprecated_prompt_format(prompt_format)
+
     attempted_topic_names = [all_topic_names[layer_id][x] for x in topic_indices]
     unique_topic_names = list(dict.fromkeys(attempted_topic_names))
     if len(unique_topic_names) == 1:
@@ -254,16 +297,7 @@ def distinguish_topic_names_prompt(
     else:
         template_set = PROMPT_TEMPLATES["disambiguate_topics"]
 
-    if prompt_format == "system_user":
-        system_prompt = template_set["system"].render(**render_params)
-        user_prompt = template_set["user"].render(**render_params)
-        return {"system": system_prompt, "user": user_prompt}
-    elif prompt_format == "combined":
-        return template_set["combined"].render(**render_params)
-    else:
-        raise ValueError(
-            f"Unsupported prompt_format: {prompt_format}. Choose 'combined' or 'system_user'."
-        )
+    return render_prompt(template_set, render_params)
 
 
 def topic_name_prompt(
@@ -282,7 +316,7 @@ def topic_name_prompt(
     max_num_exemplars: int = 128,
     exemplar_start_delimiter: str = '    * "',
     exemplar_end_delimiter: str = '"\n',
-    prompt_format: str = "combined",
+    prompt_format: Optional[str] = None,
     prompt_template: Optional[Dict[str, Any]] = None,
 ) -> Union[str, Dict[str, str]]:
     """
@@ -321,17 +355,22 @@ def topic_name_prompt(
     exemplar_end_delimiter : str, optional
         End delimiter for exemplar texts, by default "\"\n"
     prompt_format : str, optional
-        Format of the prompt, either "combined" or "system_user" to use a separate
-        system prompt, by default "combined".
+        Deprecated and ignored. Prompts now carry every rendering and the LLM
+        wrapper selects one at call time.
     prompt_template : Optional[str], optional
         Custom prompt template to use, by default None. If provided, this will override
-        the default prompt template.
+        the default prompt template. Custom templates must provide a template for each
+        of "system", "user" and "combined".
 
     Returns
     -------
-    prompt: str or dict
-        LLM Prompt for naming the topic.
+    prompt: dict or str
+        LLM Prompt for naming the topic, keyed by rendering ("system", "user" and
+        "combined"). A topic with a single already-named subtopic needs no LLM call,
+        and is returned instead as a "[!SKIP!]: <name>" string.
     """
+    handle_deprecated_prompt_format(prompt_format)
+
     if subtopics and cluster_tree is not None:
         tree_subtopics = (
             cluster_tree[(layer_id, topic_index)]
@@ -407,16 +446,7 @@ def topic_name_prompt(
     else:
         template_set = PROMPT_TEMPLATES["layer"]
 
-    if prompt_format == "system_user":
-        system_prompt = template_set["system"].render(**render_params)
-        user_prompt = template_set["user"].render(**render_params)
-        return {"system": system_prompt, "user": user_prompt}
-    elif prompt_format == "combined":
-        return template_set["combined"].render(**render_params)
-    else:
-        raise ValueError(
-            f"Unsupported prompt_format: {prompt_format}. Choose 'combined' or 'system_user'."
-        )
+    return render_prompt(template_set, render_params)
 
 
 def topic_summary_prompt(
@@ -437,11 +467,11 @@ def topic_summary_prompt(
     max_num_exemplars: int = 128,
     exemplar_start_delimiter: str = '    * "',
     exemplar_end_delimiter: str = '"\n',
-    prompt_format: str = "combined",
+    prompt_format: Optional[str] = None,
     prompt_template: Optional[Dict[str, Any]] = None,
 ) -> Union[str, Dict[str, str]]:
     """
-    Construct a prompt for naming a topic.
+    Construct a prompt for naming and summarizing a topic.
 
     Parameters
     ----------
@@ -476,17 +506,23 @@ def topic_summary_prompt(
     exemplar_end_delimiter : str, optional
         End delimiter for exemplar texts, by default "\"\n"
     prompt_format : str, optional
-        Format of the prompt, either "combined" or "system_user" to use a separate
-        system prompt, by default "combined".
+        Deprecated and ignored. Prompts now carry every rendering and the LLM
+        wrapper selects one at call time.
     prompt_template : Optional[str], optional
         Custom prompt template to use, by default None. If provided, this will override
-        the default prompt template.
+        the default prompt template. Custom templates must provide a template for each
+        of "system", "user" and "combined".
 
     Returns
     -------
-    prompt: str or dict
-        LLM Prompt for naming the topic.
+    prompt: dict or str
+        LLM Prompt for naming and summarizing the topic, keyed by rendering
+        ("system", "user" and "combined"). A topic with a single already-named
+        subtopic needs no LLM call, and is returned instead as a "[!SKIP!]: ..."
+        string carrying its name, summary and explanation.
     """
+    handle_deprecated_prompt_format(prompt_format)
+
     if subtopics and cluster_tree is not None:
         tree_subtopics = (
             cluster_tree[(layer_id, topic_index)]
@@ -584,13 +620,4 @@ def topic_summary_prompt(
     else:
         template_set = SUMMARY_PROMPT_TEMPLATES["layer"]
 
-    if prompt_format == "system_user":
-        system_prompt = template_set["system"].render(**render_params)
-        user_prompt = template_set["user"].render(**render_params)
-        return {"system": system_prompt, "user": user_prompt}
-    elif prompt_format == "combined":
-        return template_set["combined"].render(**render_params)
-    else:
-        raise ValueError(
-            f"Unsupported prompt_format: {prompt_format}. Choose 'combined' or 'system_user'."
-        )
+    return render_prompt(template_set, render_params)

--- a/toponymy/templates.py
+++ b/toponymy/templates.py
@@ -52,7 +52,8 @@ def default_extract_topic_names(json_response, old_names, topic_name_info_raw):
 
 PROMPT_TEMPLATES = {
     "layer": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert at classifying {{document_type}} from {{corpus_description}} into topics.
 Your task is to analyze information about a group of {{document_type}} and assign a {{summary_kind}} name to this group.
 The response must be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>}
@@ -71,8 +72,10 @@ You should primarily make use of the major and minor subtopics of this group to 
 and ensure the topic name reflects the core essence of *all* major subtopics.
 {% endif %}
 Ensure your entire response is only the JSON object, with no other text before or after it.
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Here is the information about the group of {{document_type}}:
 {% if cluster_keywords %}
 - Keywords for this group include: {{", ".join(cluster_keywords)}}
@@ -104,8 +107,10 @@ Here is the information about the group of {{document_type}}:
 
 Based on this information, provide a {{summary_kind}} name for this group.
 Recall the output format: {"topic_name":<NAME>, "topic_specificity":<SCORE>}.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert of classifying {{document_type}} from {{corpus_description}} into topics.
 Below is a information about a group of {{document_type}} from {{corpus_description}} that 
 are all on the same topic and need to be given topic name.
@@ -152,12 +157,14 @@ large and diverse range of {{document_type}} contained in it at a glance.
 {%- endif %}
 The response should be in JSON formatted as {"topic_name":<NAME>, "topic_specificity":<SCORE>} 
 where SCORE is a value in the range 0 to 1.
-"""),
+"""
+        ),
         "extract_topic_name": lambda json_response: str(json_response["topic_name"]),
         "get_topic_name_regex": GET_TOPIC_NAME_REGEX,
     },
     "disambiguate_topics": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}. You have been asked to provide more specific and distinguishing names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -179,8 +186,10 @@ The response must be formatted as a single JSON object in the format:
 {"new_topic_name_mapping": {"1. OLD_NAME1": "NEW_NAME1", "2. OLD_NAME2": "NEW_NAME2", ... }, "topic_specificities": [NEW_TOPIC_SCORE1, NEW_TOPIC_SCORE2, ...]}
 where SCORE is a float value between 0.0 and 1.0 representing the quality and specificity of the new name.
 Ensure your entire response is only the JSON object, with no other text before or after it.
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Below are the auto-generated topic names, along with keywords, subtopics, and sample {{document_type}} for each topic area.
 
 Original larger topic context: {{larger_topic}}
@@ -218,8 +227,10 @@ Corpus description: {{corpus_description}}
 {% endfor %}
 
 Please provide new {{summary_kind}} names for each topic, following the JSON output format specified.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}, and have been asked to provide a more specific names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -273,7 +284,8 @@ The response should be formatted as JSON in the format
     {"new_topic_name_mapping": {<1. OLD_NAME1>: <NEW_NAME1>, <2. OLD_NAME2>: <NEW_NAME2>, ... }, topic_specificities": [<NEW_TOPIC_SCORE1>, <NEW_TOPIC_SCORE2>, ...]}
 where SCORE is a value in the range 0 to 1.
 The response must contain only JSON with no preamble and must have one entry for each topic to be renamed.
-"""),
+"""
+        ),
         "extract_topic_names": default_extract_topic_names,
         "get_topic_names_regex": GET_TOPIC_CLUSTER_NAMES_REGEX,
     },
@@ -281,7 +293,8 @@ The response must contain only JSON with no preamble and must have one entry for
 
 MULTILINGUAL_EN_FR_PROMPT_TEMPLATES = {
     "layer": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert at classifying {{document_type}} from {{corpus_description}} into topics.
 Your task is to analyze information about a group of {{document_type}} and assign a {{summary_kind}} name to this group.
 The response must provide english and french topic names and must be in JSON formatted as {"english_topic_name":<NAME>, "nom_du_sujet_en_français":<NOM>, "topic_specificity":<SCORE>}
@@ -300,8 +313,10 @@ You should primarily make use of the major and minor subtopics of this group to 
 and ensure the topic name reflects the core essence of *all* major subtopics.
 {% endif %}
 Ensure your entire response is only the JSON object, with no other text before or after it.
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Here is the information about the group of {{document_type}}:
 {% if cluster_keywords %}
 - Keywords for this group include: {{", ".join(cluster_keywords)}}
@@ -333,8 +348,10 @@ Here is the information about the group of {{document_type}}:
 
 Based on this information, provide a {{summary_kind}} name for this group.
 Recall the output format: {"english_topic_name":<NAME>, "nom_du_sujet_en_français":<NOM>, "topic_specificity":<SCORE>}.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert of classifying {{document_type}} from {{corpus_description}} into topics.
 Below is a information about a group of {{document_type}} from {{corpus_description}} that 
 are all on the same topic and need to be given topic name.
@@ -381,12 +398,14 @@ large and diverse range of {{document_type}} contained in it at a glance.
 {%- endif %}
 The response should be in JSON formatted as {"english_topic_name":<NAME>, "nom_du_sujet_en_français":<NOM>, "topic_specificity":<SCORE>} 
 where SCORE is a value in the range 0 to 1.
-"""),
+"""
+        ),
         "extract_topic_name": lambda json_response: f'{json_response["english_topic_name"]} / {json_response["nom_du_sujet_en_français"]}',
         "get_topic_name_regex": r'\{\s*"english_topic_name":\s*.*?,\s*"nom_du_sujet_en_français":\s*.*?,\s*"topic_specificity":\s*[\w.]+\s*\}',
     },
     "disambiguate_topics": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}. You have been asked to provide more specific and distinguishing names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -408,8 +427,10 @@ The response must be formatted as a single JSON object in the format:
 {"new_topic_name_mapping": {"1. OLD_NAME1 / ANCIEN_NOM1": "NEW_NAME1 / NOUVEAU_NOM1", "2. OLD_NAME2 / ANCIEN_NOM2": "NEW_NAME2 / NOUVEAU_NOM2", ... }, "topic_specificities": [NEW_TOPIC_SCORE1, NEW_TOPIC_SCORE2, ...]}
 where SCORE is a float value between 0.0 and 1.0 representing the quality and specificity of the new name.
 Ensure your entire response is only the JSON object, with no other text before or after it.
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Below are the auto-generated topic names, along with keywords, subtopics, and sample {{document_type}} for each topic area.
 
 Original larger topic context: {{larger_topic}}
@@ -447,8 +468,10 @@ Corpus description: {{corpus_description}}
 {% endfor %}
 
 Please provide new {{summary_kind}} names for each topic, following the JSON output format specified.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}, and have been asked to provide a more specific names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -502,7 +525,8 @@ The response should be formatted as JSON in the format
     {"new_topic_name_mapping": {<1. OLD_NAME1 / ANCIEN_NOM1>: <NEW_NAME1 / NOUVEAU_NOM1>, <2. OLD_NAME2 / ANCIEN_NOM2>: <NEW_NAME2 / NOUVEAU_NOM2>, ... }, topic_specificities": [<NEW_TOPIC_SCORE1>, <NEW_TOPIC_SCORE2>, ...]}
 where SCORE is a value in the range 0 to 1.
 The response must contain only JSON with no preamble and must have one entry for each topic to be renamed.
-"""),
+"""
+        ),
         "extract_topic_names": default_extract_topic_names,
         "get_topic_names_regex": GET_TOPIC_CLUSTER_NAMES_REGEX,
     },
@@ -510,7 +534,8 @@ The response must contain only JSON with no preamble and must have one entry for
 
 SUMMARY_PROMPT_TEMPLATES = {
     "layer": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert at classifying {{document_type}} from {{corpus_description}} into topics.
 Your task is to analyze information about a group of {{document_type}} and provide a thorough analysis of the topic,
 a short paragraph summary, and a {{summary_kind}} name for the group.
@@ -540,8 +565,10 @@ should cover the full breadth of subtopics to ensure it captures the full breadt
 content within the topic.
 {% endif %}
  Ensure your entire response is only the JSON object, with no other text before or after it. Keep all JSON string values on a single line (escape any newlines as \\n).
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Here is the information about the group of {{document_type}}:
 {% if cluster_keywords %}
 - Keywords for this group include: {{", ".join(cluster_keywords)}}
@@ -579,8 +606,10 @@ Here is the information about the group of {{document_type}}:
 
 Based on this information, provide a detailed topic analysis, a summary, and a {{summary_kind}} name for this group.
 Recall the output format: {"topic_analysis":<ANALYSIS>, "topic_summary":<SUMMARY>, "topic_name":<NAME>, "topic_specificity":<SCORE>}.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert of classifying {{document_type}} from {{corpus_description}} into topics.
 Below is a information about a group of {{document_type}} from {{corpus_description}} that 
 are all on the same topic and need to be given a thorough analysis of the topic,
@@ -644,7 +673,8 @@ where ANALYSIS is a thorough analytical discussion of the topic's content, key t
 (written to inform the summary and name that follow), SUMMARY is a short paragraph summary of the topic,
 NAME is the topic name you generate, and SCORE is a float value between 0.0 and 1.0,
 representing how specific and well-defined the topic name is given the input information.
-"""),
+"""
+        ),
         "extract_topic_name": lambda json_response: (
             json_response["topic_name"],
             json_response["topic_summary"],
@@ -653,7 +683,8 @@ representing how specific and well-defined the topic name is given the input inf
         "get_topic_name_regex": GET_TOPIC_NAME_AND_SUMMARY_REGEX,
     },
     "disambiguate_topics": {
-        "system": jinja2.Template("""
+        "system": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}. You have been asked to provide more specific and distinguishing names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -675,8 +706,10 @@ The response must be formatted as a single JSON object in the format:
 {"new_topic_name_mapping": {"1. OLD_NAME1": "NEW_NAME1", "2. OLD_NAME2": "NEW_NAME2", ... }, "topic_specificities": [NEW_TOPIC_SCORE1, NEW_TOPIC_SCORE2, ...]}
 where SCORE is a float value between 0.0 and 1.0 representing the quality and specificity of the new name.
 Ensure your entire response is only the JSON object, with no other text before or after it.
-"""),
-        "user": jinja2.Template("""
+"""
+        ),
+        "user": jinja2.Template(
+            """
 Below are the auto-generated topic names, along with keywords, subtopics, and sample {{document_type}} for each topic area.
 
 Original larger topic context: {{larger_topic}}
@@ -720,8 +753,10 @@ Corpus description: {{corpus_description}}
 {% endfor %}
 
 Please provide new {{summary_kind}} names for each topic, following the JSON output format specified.
-"""),
-        "combined": jinja2.Template("""
+"""
+        ),
+        "combined": jinja2.Template(
+            """
 You are an expert in {{larger_topic}}, and have been asked to provide a more specific names for various groups of
 {{document_type}} from {{corpus_description}} that have been assigned overly similar auto-generated topic names.
 
@@ -781,7 +816,8 @@ The response should be formatted as JSON in the format
     {"new_topic_name_mapping": {<1. OLD_NAME1>: <NEW_NAME1>, <2. OLD_NAME2>: <NEW_NAME2>, ... }, topic_specificities": [<NEW_TOPIC_SCORE1>, <NEW_TOPIC_SCORE2>, ...]}
 where SCORE is a value in the range 0 to 1.
 The response must contain only JSON with no preamble and must have one entry for each topic to be renamed.
-"""),
+"""
+        ),
         "extract_topic_names": default_extract_topic_names,
         "get_topic_names_regex": GET_TOPIC_CLUSTER_NAMES_REGEX,
     },

--- a/toponymy/tests/helpers/llm_test_config.py
+++ b/toponymy/tests/helpers/llm_test_config.py
@@ -78,6 +78,20 @@ def make_mock_data():
     }
 
 
+def make_prompt(label: object = "test") -> dict:
+    """
+    Build a prompt of the shape toponymy.prompt_construction produces.
+
+    Prompts carry every rendering, and the LLM wrapper picks one at call time, so a
+    test prompt needs all of them regardless of which one the wrapper under test uses.
+    """
+    return {
+        "system": f"system prompt {label}",
+        "user": f"user prompt {label}",
+        "combined": f"combined prompt {label}",
+    }
+
+
 # Helper functions for validation
 def validate_topic_name(result: str):
     assert result == "Machine Learning"

--- a/toponymy/tests/test__utils.py
+++ b/toponymy/tests/test__utils.py
@@ -179,7 +179,9 @@ class TestHandleVerboseParams:
             show_pb, verbose = handle_verbose_params(verbose_legacy=True)
 
         assert verbose is True
-        assert show_pb is True  # When verbose_legacy=True, progress bar should also be True
+        assert (
+            show_pb is True
+        )  # When verbose_legacy=True, progress bar should also be True
 
     def test_show_progress_bars_with_deprecation_warning(self):
         """show_progress_bars should work with deprecation warning."""

--- a/toponymy/tests/test_async_llm_wrappers.py
+++ b/toponymy/tests/test_async_llm_wrappers.py
@@ -357,7 +357,9 @@ def test_async_azureai_namer_default():
 
 
 def test_async_azureai_namer_provider_kwargs_passthrough():
-    namer = AsyncAzureAINamer(api_key="dummy", model="dummy", provider_kwargs={"timeout": 123})
+    namer = AsyncAzureAINamer(
+        api_key="dummy", model="dummy", provider_kwargs={"timeout": 123}
+    )
 
     assert namer.provider_kwargs["timeout"] == 123
 

--- a/toponymy/tests/test_async_llm_wrappers.py
+++ b/toponymy/tests/test_async_llm_wrappers.py
@@ -19,6 +19,7 @@ from toponymy.llm_wrappers import (
     CallResult,
 )
 from toponymy.tests.helpers.llm_test_config import (
+    make_prompt,
     validate_topic_name,
     validate_cluster_names,
     LITELLM_PROVIDER_CASES,
@@ -579,7 +580,7 @@ async def test_async_litellm_generate_topic_names_success(
     response = MockAsyncResponse.create_chat_response(mock_data["valid_topic_name"])
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
-        result = await async_litellm_wrapper.generate_topic_names(["test prompt"])
+        result = await async_litellm_wrapper.generate_topic_names([make_prompt()])
 
     assert len(result) == 1
     validate_topic_name(result[0])
@@ -593,9 +594,7 @@ async def test_async_litellm_generate_topic_names_system_prompt(
     response = MockAsyncResponse.create_chat_response(mock_data["valid_topic_name"])
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
-        result = await async_litellm_wrapper.generate_topic_names(
-            [{"system": "system prompt", "user": "test prompt"}]
-        )
+        result = await async_litellm_wrapper.generate_topic_names([make_prompt()])
 
     assert len(result) == 1
     validate_topic_name(result[0])
@@ -610,7 +609,7 @@ async def test_async_litellm_generate_topic_cluster_names_success(
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
         result = await async_litellm_wrapper.generate_topic_cluster_names(
-            ["test prompt"],
+            [make_prompt()],
             [mock_data["old_names"]],
         )
 
@@ -627,7 +626,7 @@ async def test_async_litellm_generate_topic_cluster_names_system_prompt(
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
         result = await async_litellm_wrapper.generate_topic_cluster_names(
-            [{"system": "system prompt", "user": "test prompt"}],
+            [make_prompt()],
             [mock_data["old_names"]],
         )
 
@@ -643,7 +642,7 @@ async def test_async_litellm_generate_topic_names_prompt_list(
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
         result = await async_litellm_wrapper.generate_topic_names(
-            ["prompt1", "prompt2", "prompt3"]
+            [make_prompt(1), make_prompt(2), make_prompt(3)]
         )
     assert len(result) == 3
     assert all(name == "Machine Learning" for name in result)
@@ -657,7 +656,7 @@ async def test_async_litellm_generate_topic_cluster_names_prompt_list(
     response = MockAsyncResponse.create_chat_response(mock_data["valid_cluster_names"])
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
         old_names_list = [["data", "ml", "ai"], ["x", "y", "z"]]
-        prompts = ["prompt1", "prompt2"]
+        prompts = [make_prompt(1), make_prompt(2)]
 
         result = await async_litellm_wrapper.generate_topic_cluster_names(
             prompts, old_names_list
@@ -675,7 +674,7 @@ async def test_async_litellm_generate_topic_cluster_names_malformed_mapping(
 
     with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
         result = await async_litellm_wrapper.generate_topic_cluster_names(
-            ["test prompt"],
+            [make_prompt()],
             [mock_data["old_names"]],
         )
 
@@ -694,7 +693,7 @@ async def test_async_litellm_generate_topic_names_fail_fast_raises(
         new=AsyncMock(side_effect=make_litellm_error(error_class)),
     ):
         with pytest.raises(FailFastLLMError):
-            await async_litellm_wrapper.generate_topic_names(["test prompt"])
+            await async_litellm_wrapper.generate_topic_names([make_prompt()])
 
 
 @pytest.mark.asyncio
@@ -708,7 +707,7 @@ async def test_async_litellm_generate_topic_names_retryable_returns_empty(
         "litellm.acompletion",
         new=AsyncMock(side_effect=[make_litellm_error(error_class) for _ in range(3)]),
     ) as mock_acompletion:
-        result = await async_litellm_wrapper.generate_topic_names(["test prompt"])
+        result = await async_litellm_wrapper.generate_topic_names([make_prompt()])
 
     assert result == [""]
     assert mock_acompletion.await_count == 3
@@ -727,7 +726,7 @@ async def test_async_litellm_generate_topic_cluster_names_retryable_returns_old_
         new=AsyncMock(side_effect=[make_litellm_error(error_class) for _ in range(3)]),
     ):
         result = await async_litellm_wrapper.generate_topic_cluster_names(
-            ["test prompt"],
+            [make_prompt()],
             [mock_data["old_names"]],
         )
 
@@ -744,29 +743,30 @@ async def test_async_litellm_retries_per_item_not_whole_batch(
         mock_data["valid_topic_name"]
     )
     error_class = LITELLM_RETRYABLE[0]
-    call_counts = {"prompt1": 0, "prompt2": 0}
+    call_counts = {"user prompt 1": 0, "user prompt 2": 0}
 
     async def mock_acompletion(**kwargs):
-        prompt_text = kwargs["messages"][0]["content"]
+        # messages[0] is the system prompt, messages[1] the user prompt
+        prompt_text = kwargs["messages"][1]["content"]
         call_counts[prompt_text] += 1
 
-        if prompt_text == "prompt1":
+        if prompt_text == "user prompt 1":
             return good_response
-        if prompt_text == "prompt2":
+        if prompt_text == "user prompt 2":
             raise make_litellm_error(error_class)
 
         raise AssertionError(f"Unexpected prompt: {prompt_text}")
 
     with patch("litellm.acompletion", new=AsyncMock(side_effect=mock_acompletion)):
         result = await async_litellm_wrapper.generate_topic_names(
-            ["prompt1", "prompt2"]
+            [make_prompt(1), make_prompt(2)]
         )
 
     assert len(result) == 2
     validate_topic_name(result[0])
     assert result[1] == ""
-    assert call_counts["prompt1"] == 1
-    assert call_counts["prompt2"] == 3
+    assert call_counts["user prompt 1"] == 1
+    assert call_counts["user prompt 2"] == 3
 
 
 @pytest.mark.asyncio
@@ -780,7 +780,7 @@ async def test_async_litellm_generate_topic_names_retry_exhausted_warns(
         new=AsyncMock(side_effect=[make_litellm_error(error_class) for _ in range(3)]),
     ):
         with pytest.warns(UserWarning, match="Failed to generate topic name"):
-            result = await async_litellm_wrapper.generate_topic_names(["test prompt"])
+            result = await async_litellm_wrapper.generate_topic_names([make_prompt()])
 
     assert result == [""]
 
@@ -798,7 +798,7 @@ async def test_async_litellm_generate_topic_cluster_names_retry_exhausted_warns(
     ):
         with pytest.warns(UserWarning):
             result = await async_litellm_wrapper.generate_topic_cluster_names(
-                ["test prompt"],
+                [make_prompt()],
                 [mock_data["old_names"]],
             )
 
@@ -854,8 +854,7 @@ async def test_async_litellm_system_prompt_probe_falls_back_and_caches(
         new=AsyncMock(side_effect=[unsupported_error, good_response]),
     ) as mock_acompletion:
         result = await async_litellm_wrapper._call_single_llm_with_system(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -877,8 +876,7 @@ async def test_async_litellm_system_prompt_cached_false_flattens_immediately(
         new=AsyncMock(return_value=good_response),
     ) as mock_acompletion:
         await async_litellm_wrapper._call_single_llm_with_system(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -903,8 +901,7 @@ async def test_async_litellm_system_prompt_probe_success_caches_true(
         new=AsyncMock(return_value=good_response),
     ):
         result = await async_litellm_wrapper._call_single_llm_with_system(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -926,7 +923,7 @@ async def test_async_litellm_namer_temperature_override_is_used(mock_data):
         "litellm.acompletion",
         new=AsyncMock(return_value=response),
     ) as mock_acompletion:
-        result = await wrapper.generate_topic_names(["test prompt"], temperature=0.9)
+        result = await wrapper.generate_topic_names([make_prompt()], temperature=0.9)
 
     assert mock_acompletion.await_args.kwargs["temperature"] == 0.0
     assert len(result) == 1
@@ -966,5 +963,5 @@ async def test_async_wrapper_invalid_input(async_litellm_wrapper):
 
     with pytest.raises(ValueError):
         await async_litellm_wrapper.generate_topic_cluster_names(
-            ["prompt1", "prompt2"], [["name1", "name2"]]
+            [make_prompt(1), make_prompt(2)], [["name1", "name2"]]
         )  # Mismatched lengths

--- a/toponymy/tests/test_async_llm_wrappers_base.py
+++ b/toponymy/tests/test_async_llm_wrappers_base.py
@@ -8,6 +8,7 @@ from toponymy.llm_wrappers import (
 )
 
 from toponymy.tests.helpers.llm_test_config import (
+    make_prompt,
     validate_topic_name,
     validate_cluster_names,
 )
@@ -35,9 +36,7 @@ class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         raise DummyAsyncProviderError("bad config")
 
-    async def _call_single_llm_with_system(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    async def _call_single_llm_with_system(self, prompt, temperature, max_tokens):
         raise DummyAsyncProviderError("bad config")
 
 
@@ -48,9 +47,7 @@ class DummySingleWrapper(AsyncLLMWrapper):
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
 
-    async def _call_single_llm_with_system(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    async def _call_single_llm_with_system(self, prompt, temperature, max_tokens):
         return "single-system-ok"
 
 
@@ -61,9 +58,17 @@ class DummyBatchWrapper(AsyncLLMWrapper):
         return ["batch-ok"]
 
     async def _call_llm_with_system_prompt_batch(
-        self, system_prompts, user_prompts, temperature, max_tokens
+        self, prompts, temperature, max_tokens
     ):
         return ["batch-system-ok"]
+
+
+class DummyCombinedOnlyWrapper(DummySingleWrapper):
+    """A wrapper whose provider has no system role, so it takes the combined rendering."""
+
+    @property
+    def supports_system_prompts(self) -> bool:
+        return False
 
 
 class DummyBatchCallResultWrapper(AsyncLLMWrapper):
@@ -254,30 +259,31 @@ async def test_async_generate_topic_cluster_names_length_mismatch_raises():
 
 
 @pytest.mark.asyncio
-async def test_async_generate_topic_names_routes_string_prompts_to_call_llm_batch():
-    wrapper = DummySingleWrapper()
+async def test_async_generate_topic_names_routes_to_batch_without_system_prompts():
+    wrapper = DummyCombinedOnlyWrapper()
     wrapper._call_llm_batch = AsyncMock(return_value=[])
 
-    await wrapper.generate_topic_names(["test prompt"])
+    prompts = [make_prompt(1)]
+    await wrapper.generate_topic_names(prompts)
 
+    # The whole prompt is passed through, not just the rendering that gets used.
     wrapper._call_llm_batch.assert_awaited_once_with(
-        ["test prompt"],
+        prompts,
         0.4,
         max_tokens=128,
     )
 
 
 @pytest.mark.asyncio
-async def test_async_generate_topic_names_routes_dict_prompts_to_call_with_system_prompt_batch():
+async def test_async_generate_topic_names_routes_to_system_prompt_batch():
     wrapper = DummySingleWrapper()
     wrapper._call_llm_with_system_prompt_batch = AsyncMock(return_value=[])
 
-    prompts = [{"system": "system prompt", "user": "test prompt"}]
+    prompts = [make_prompt(1)]
     await wrapper.generate_topic_names(prompts)
 
     wrapper._call_llm_with_system_prompt_batch.assert_awaited_once_with(
-        ["system prompt"],
-        ["test prompt"],
+        prompts,
         0.4,
         max_tokens=128,
     )
@@ -289,7 +295,7 @@ async def test_async_generate_topic_names_partial_success(
     mock_data,
 ):
     wrapper = DummySingleWrapper()
-    wrapper._call_llm_batch = AsyncMock(
+    wrapper._call_llm_with_system_prompt_batch = AsyncMock(
         return_value=[
             MockCallResult.success(mock_data["valid_topic_name"]),
             MockCallResult.failure(),
@@ -297,7 +303,9 @@ async def test_async_generate_topic_names_partial_success(
         ]
     )
 
-    result = await wrapper.generate_topic_names(["prompt 1", "prompt 2", "prompt 3"])
+    result = await wrapper.generate_topic_names(
+        [make_prompt(1), make_prompt(2), make_prompt(3)]
+    )
 
     validate_topic_name(result[0])
     assert result[1] == ""
@@ -310,7 +318,7 @@ async def test_async_generate_topic_cluster_names_partial_success(
     mock_data,
 ):
     wrapper = DummySingleWrapper()
-    wrapper._call_llm_batch = AsyncMock(
+    wrapper._call_llm_with_system_prompt_batch = AsyncMock(
         return_value=[
             MockCallResult.success(mock_data["valid_cluster_names"]),
             MockCallResult.failure(),
@@ -325,7 +333,7 @@ async def test_async_generate_topic_cluster_names_partial_success(
         mock_data["old_names"],
     ]
     result = await wrapper.generate_topic_cluster_names(
-        ["prompt 1", "prompt 2", "prompt 3"],
+        [make_prompt(1), make_prompt(2), make_prompt(3)],
         old_names,
     )
 

--- a/toponymy/tests/test_cluster_layer_summary.py
+++ b/toponymy/tests/test_cluster_layer_summary.py
@@ -149,7 +149,6 @@ def test_summary_make_data_alternative_methods1(
         cluster_centroid_vectors,
         1,
         embedder,
-        prompt_format="system_user",
     )
     keyphrase_builder = KeyphraseBuilder()
     matrix, keyphrases, vectors = keyphrase_builder.fit_transform(all_sentences)
@@ -216,7 +215,6 @@ def test_summary_make_data_alternative_methods2(
         cluster_centroid_vectors,
         1,
         embedder,
-        prompt_format="combined",
     )
     keyphrase_builder = KeyphraseBuilder()
     matrix, keyphrases, vectors = keyphrase_builder.fit_transform(all_sentences)

--- a/toponymy/tests/test_cluster_layers.py
+++ b/toponymy/tests/test_cluster_layers.py
@@ -138,7 +138,6 @@ def test_make_data_alternative_methods1(
         cluster_centroid_vectors,
         1,
         embedder,
-        prompt_format="system_user",
     )
     keyphrase_builder = KeyphraseBuilder()
     matrix, keyphrases, vectors = keyphrase_builder.fit_transform(all_sentences)
@@ -186,7 +185,6 @@ def test_make_data_alternative_methods2(
         cluster_centroid_vectors,
         1,
         embedder,
-        prompt_format="combined",
     )
     keyphrase_builder = KeyphraseBuilder()
     matrix, keyphrases, vectors = keyphrase_builder.fit_transform(all_sentences)
@@ -215,3 +213,60 @@ def test_make_data_alternative_methods2(
         "about specific popular topics",
         cluster_tree,
     )
+
+
+def test_cluster_layer_prompt_format_is_deprecated_and_ignored(
+    embedder,
+    cluster_label_vector,
+    cluster_centroid_vectors,
+):
+    with pytest.warns(DeprecationWarning, match="prompt_format is deprecated"):
+        cluster_layer = ClusterLayerText(
+            cluster_label_vector,
+            cluster_centroid_vectors,
+            1,
+            embedder,
+            prompt_format="system_user",
+        )
+
+    assert not hasattr(cluster_layer, "prompt_format")
+
+
+def test_make_prompts_produces_every_rendering(
+    all_sentences,
+    object_vectors,
+    embedder,
+    all_subtopics,
+    subtopic_label_vector,
+    subtopic_centroid_vectors,
+    cluster_tree,
+    cluster_label_vector,
+    cluster_centroid_vectors,
+):
+    """Prompts reach the LLM wrapper carrying every rendering, whatever it supports."""
+    cluster_layer = ClusterLayerText(
+        cluster_label_vector,
+        cluster_centroid_vectors,
+        1,
+        embedder,
+    )
+    keyphrase_builder = KeyphraseBuilder()
+    matrix, keyphrases, vectors = keyphrase_builder.fit_transform(all_sentences)
+    keyphrase_vectors = embedder.encode(keyphrases)
+    cluster_layer.make_exemplar_texts(all_sentences, object_vectors)
+    cluster_layer.make_keyphrases(keyphrases, matrix, keyphrase_vectors, embedder)
+    cluster_layer.make_subtopics(
+        all_subtopics, subtopic_label_vector, subtopic_centroid_vectors
+    )
+
+    prompts = cluster_layer.make_prompts(
+        1.0,
+        [all_subtopics, []],
+        "sentences",
+        "about specific popular topics",
+        cluster_tree,
+    )
+
+    assert prompts
+    for prompt in prompts:
+        assert set(prompt) == {"system", "user", "combined"}

--- a/toponymy/tests/test_embedding_wrappers.py
+++ b/toponymy/tests/test_embedding_wrappers.py
@@ -43,10 +43,12 @@ class TestCohereEmbedder:
         # Verify that CO_API_KEY works with deprecation warning
         monkeypatch.delenv("COHERE_API_KEY", raising=False)
         monkeypatch.setenv("CO_API_KEY", "dummy")
-        
-        with pytest.warns(FutureWarning, match="CO_API_KEY.*deprecated.*COHERE_API_KEY"):
+
+        with pytest.warns(
+            FutureWarning, match="CO_API_KEY.*deprecated.*COHERE_API_KEY"
+        ):
             embedder = embedders.CohereEmbedder()
-        
+
         # Verify the embedder was created (mock client was called)
         mock_client_v2.assert_called_once_with(api_key="dummy")
 

--- a/toponymy/tests/test_llm_wrapper_base.py
+++ b/toponymy/tests/test_llm_wrapper_base.py
@@ -6,7 +6,12 @@ from toponymy.llm_wrappers import (
     InvalidLLMInputError,
     repair_json_string_backslashes,
 )
+from toponymy.tests.helpers.llm_test_config import (
+    make_prompt,
+    validate_topic_name,
+)
 import pytest
+from unittest.mock import Mock
 
 
 class DummySingleWrapper(LLMWrapper):
@@ -16,10 +21,16 @@ class DummySingleWrapper(LLMWrapper):
     def _call_llm(self, prompt, temperature, max_tokens):
         return "single-ok"
 
-    def _call_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    def _call_llm_with_system_prompt(self, prompt, temperature, max_tokens):
         return "single-system-ok"
+
+
+class DummyCombinedOnlyWrapper(DummySingleWrapper):
+    """A wrapper whose provider has no system role, so it takes the combined rendering."""
+
+    @property
+    def supports_system_prompts(self) -> bool:
+        return False
 
 
 class DummyFailureWrapper(LLMWrapper):
@@ -29,9 +40,7 @@ class DummyFailureWrapper(LLMWrapper):
     def _call_llm(self, prompt, temperature, max_tokens):
         raise RuntimeError("error")
 
-    def _call_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    def _call_llm_with_system_prompt(self, prompt, temperature, max_tokens):
         raise RuntimeError("error")
 
 
@@ -46,9 +55,7 @@ class DummyFailFastWrapper(LLMWrapper):
     def _call_llm(self, prompt, temperature, max_tokens):
         raise DummyFailFastProviderError("bad config")
 
-    def _call_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    def _call_llm_with_system_prompt(self, prompt, temperature, max_tokens):
         raise DummyFailFastProviderError("bad config")
 
 
@@ -59,9 +66,7 @@ class DummyAsyncSingleWrapper(AsyncLLMWrapper):
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         return "async-single-ok"
 
-    async def _call_single_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    async def _call_single_llm_with_system(self, prompt, temperature, max_tokens):
         return "async-system-ok"
 
 
@@ -72,9 +77,7 @@ class DummyAsyncFailureWrapper(AsyncLLMWrapper):
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         raise RuntimeError("error")
 
-    async def _call_single_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    async def _call_single_llm_with_system(self, prompt, temperature, max_tokens):
         raise RuntimeError("error")
 
 
@@ -90,9 +93,7 @@ class DummyAsyncFailFastWrapper(AsyncLLMWrapper):
     async def _call_single_llm(self, prompt, temperature, max_tokens):
         raise DummyAsyncFailFastProviderError("bad config")
 
-    async def _call_single_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    async def _call_single_llm_with_system(self, prompt, temperature, max_tokens):
         raise DummyAsyncFailFastProviderError("bad config")
 
 
@@ -168,7 +169,7 @@ def test_safe_call_llm_wraps_fail_fast_exception():
     wrapper = DummyFailFastWrapper()
 
     with pytest.raises(FailFastLLMError, match="dummy-model"):
-        wrapper._safe_call_llm("prompt", temperature=0.4, max_tokens=128)
+        wrapper._safe_call_llm({"combined": "prompt"}, temperature=0.4, max_tokens=128)
 
 
 def test_safe_call_llm_with_system_prompt_wraps_fail_fast_exception():
@@ -176,8 +177,7 @@ def test_safe_call_llm_with_system_prompt_wraps_fail_fast_exception():
 
     with pytest.raises(FailFastLLMError, match="dummy-model"):
         wrapper._safe_call_llm_with_system_prompt(
-            "system prompt",
-            "user prompt",
+            {"system": "system prompt", "user": "user prompt"},
             temperature=0.4,
             max_tokens=128,
         )
@@ -200,6 +200,54 @@ def test_generate_topic_cluster_names_invalid_prompt_type_raises():
         )
 
 
+def test_generate_topic_name_missing_rendering_raises():
+    wrapper = DummySingleWrapper()
+
+    with pytest.raises(InvalidLLMInputError, match="missing the system rendering"):
+        wrapper.generate_topic_name({"user": "user prompt", "combined": "combined"})
+
+
+def test_generate_topic_name_uses_system_rendering_when_supported(mock_data):
+    wrapper = DummySingleWrapper()
+    wrapper._call_llm_with_system_prompt = Mock(
+        return_value=mock_data["valid_topic_name"]
+    )
+    wrapper._call_llm = Mock()
+
+    prompt = make_prompt()
+    validate_topic_name(wrapper.generate_topic_name(prompt))
+
+    wrapper._call_llm.assert_not_called()
+    # The whole prompt is passed through, not just the rendering that gets used.
+    assert wrapper._call_llm_with_system_prompt.call_args.args[0] == prompt
+
+
+def test_generate_topic_name_uses_combined_rendering_without_system_prompts(mock_data):
+    wrapper = DummyCombinedOnlyWrapper()
+    wrapper._call_llm = Mock(return_value=mock_data["valid_topic_name"])
+    wrapper._call_llm_with_system_prompt = Mock()
+
+    prompt = make_prompt()
+    validate_topic_name(wrapper.generate_topic_name(prompt))
+
+    wrapper._call_llm_with_system_prompt.assert_not_called()
+    assert wrapper._call_llm.call_args.args[0] == prompt
+
+
+def test_generate_topic_cluster_names_uses_combined_rendering_without_system_prompts(
+    mock_data,
+):
+    wrapper = DummyCombinedOnlyWrapper()
+    wrapper._call_llm = Mock(return_value=mock_data["valid_cluster_names"])
+    wrapper._call_llm_with_system_prompt = Mock()
+
+    prompt = make_prompt()
+    wrapper.generate_topic_cluster_names(prompt, mock_data["old_names"])
+
+    wrapper._call_llm_with_system_prompt.assert_not_called()
+    assert wrapper._call_llm.call_args.args[0] == prompt
+
+
 def test_supports_system_prompts_defaults_true():
     wrapper = DummySingleWrapper()
     assert wrapper.supports_system_prompts is True
@@ -219,7 +267,7 @@ def test_safe_call_llm_emits_debug_callback_on_success():
     wrapper.callback = lambda payload: events.append(payload)
 
     result = wrapper._safe_call_llm(
-        "test prompt",
+        {"combined": "test prompt"},
         temperature=0.4,
         max_tokens=128,
     )
@@ -227,7 +275,7 @@ def test_safe_call_llm_emits_debug_callback_on_success():
     assert result == "single-ok"
     assert len(events) == 1
     assert events[0]["event"] == "llm_call_success"
-    assert events[0]["prompt"] == "test prompt"
+    assert events[0]["prompt"] == {"combined": "test prompt"}
     assert events[0]["raw_response"] == "single-ok"
     assert events[0]["model"] == "dummy-model"
     assert events[0]["wrapper"] == "DummySingleWrapper"
@@ -241,8 +289,7 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_success():
     wrapper.callback = lambda payload: events.append(payload)
 
     result = wrapper._safe_call_llm_with_system_prompt(
-        "system prompt",
-        "user prompt",
+        {"system": "system prompt", "user": "user prompt"},
         temperature=0.4,
         max_tokens=128,
     )
@@ -265,14 +312,14 @@ def test_safe_call_llm_emits_debug_callback_on_error():
 
     with pytest.raises(RuntimeError, match="error"):
         wrapper._safe_call_llm(
-            "test prompt",
+            {"combined": "test prompt"},
             temperature=0.4,
             max_tokens=128,
         )
 
     assert len(events) == 1
     assert events[0]["event"] == "llm_call_error"
-    assert events[0]["prompt"] == "test prompt"
+    assert events[0]["prompt"] == {"combined": "test prompt"}
     assert events[0]["error"]["type"] == "RuntimeError"
     assert events[0]["error"]["message"] == "error"
 
@@ -285,8 +332,7 @@ def test_safe_call_llm_with_system_prompt_emits_debug_callback_on_error():
 
     with pytest.raises(RuntimeError, match="error"):
         wrapper._safe_call_llm_with_system_prompt(
-            "system prompt",
-            "user prompt",
+            {"system": "system prompt", "user": "user prompt"},
             temperature=0.4,
             max_tokens=128,
         )

--- a/toponymy/tests/test_llm_wrappers.py
+++ b/toponymy/tests/test_llm_wrappers.py
@@ -26,6 +26,7 @@ from conftest import ollama_has_model
 from toponymy.tools.notebook_test_helpers import get_test_ollama_model
 
 from toponymy.tests.helpers.llm_test_config import (
+    make_prompt,
     validate_cluster_names,
     validate_topic_name,
     LITELLM_PROVIDER_CASES,
@@ -117,7 +118,7 @@ def test_llamacpp_generate_topic_name_success(llamacpp_wrapper, mock_data):
     response = MockLLMResponse.create_llama_response(mock_data["valid_topic_name"])
     llamacpp_wrapper.llm = Mock(return_value=response)
 
-    result = llamacpp_wrapper.generate_topic_name("test prompt")
+    result = llamacpp_wrapper.generate_topic_name(make_prompt())
     validate_topic_name(result)
 
 
@@ -126,7 +127,7 @@ def test_llamacpp_generate_cluster_names_success(llamacpp_wrapper, mock_data):
     llamacpp_wrapper.llm = Mock(return_value=response)
 
     result = llamacpp_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     validate_cluster_names(result)
 
@@ -138,7 +139,7 @@ def test_llamacpp_generate_cluster_names_success_on_malformed_mapping(
     llamacpp_wrapper.llm = Mock(return_value=response)
 
     result = llamacpp_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     validate_cluster_names(result)
 
@@ -146,7 +147,7 @@ def test_llamacpp_generate_cluster_names_success_on_malformed_mapping(
 @pytest.mark.filterwarnings("ignore:All retries exhausted")
 def test_llamacpp_generate_topic_name_failure(llamacpp_wrapper):
     llamacpp_wrapper.llm = Mock(side_effect=Exception("API Error"))
-    result = llamacpp_wrapper.generate_topic_name("test prompt")
+    result = llamacpp_wrapper.generate_topic_name(make_prompt())
     assert result == ""
 
 
@@ -156,7 +157,7 @@ def test_llamacpp_generate_topic_name_failure_malformed_json(
 ):
     response = MockLLMResponse.create_llama_response(mock_data["malformed_json"])
     llamacpp_wrapper.llm = Mock(return_value=response)
-    result = llamacpp_wrapper.generate_topic_name("test prompt")
+    result = llamacpp_wrapper.generate_topic_name(make_prompt())
     assert result == ""
 
 
@@ -164,7 +165,7 @@ def test_llamacpp_generate_topic_name_failure_malformed_json(
 def test_llamacpp_generate_cluster_names_failure(llamacpp_wrapper, mock_data):
     llamacpp_wrapper.llm = Mock(side_effect=Exception("API Error"))
     result = llamacpp_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     assert result == mock_data["old_names"]
 
@@ -183,7 +184,7 @@ def test_huggingface_generate_topic_name_success(huggingface_wrapper, mock_data)
     )
     huggingface_wrapper.llm = Mock(return_value=response)
 
-    result = huggingface_wrapper.generate_topic_name("test prompt")
+    result = huggingface_wrapper.generate_topic_name(make_prompt())
     validate_topic_name(result)
 
 
@@ -195,9 +196,7 @@ def test_huggingface_generate_topic_name_success_system_prompt(
     )
     huggingface_wrapper.llm = Mock(return_value=response)
 
-    result = huggingface_wrapper.generate_topic_name(
-        {"system": "system prompt", "user": "test prompt"}
-    )
+    result = huggingface_wrapper.generate_topic_name(make_prompt())
     validate_topic_name(result)
 
 
@@ -208,7 +207,7 @@ def test_huggingface_generate_cluster_names_success(huggingface_wrapper, mock_da
     huggingface_wrapper.llm = Mock(return_value=response)
 
     result = huggingface_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     validate_cluster_names(result)
 
@@ -222,7 +221,7 @@ def test_huggingface_generate_cluster_names_success_system_prompt(
     huggingface_wrapper.llm = Mock(return_value=response)
 
     result = huggingface_wrapper.generate_topic_cluster_names(
-        {"system": "system prompt", "user": "test prompt"}, mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     validate_cluster_names(result)
 
@@ -236,7 +235,7 @@ def test_huggingface_generate_cluster_names_success_on_malformed_mapping(
     huggingface_wrapper.llm = Mock(return_value=response)
 
     result = huggingface_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     validate_cluster_names(result)
 
@@ -244,7 +243,7 @@ def test_huggingface_generate_cluster_names_success_on_malformed_mapping(
 @pytest.mark.filterwarnings("ignore:All retries exhausted")
 def test_huggingface_generate_topic_name_failure(huggingface_wrapper):
     huggingface_wrapper.llm = Mock(side_effect=Exception("API Error"))
-    result = huggingface_wrapper.generate_topic_name("test prompt")
+    result = huggingface_wrapper.generate_topic_name(make_prompt())
     assert result == ""
 
 
@@ -254,7 +253,7 @@ def test_huggingface_generate_topic_name_failure_malformed_json(
 ):
     response = MockLLMResponse.create_huggingface_response(mock_data["malformed_json"])
     huggingface_wrapper.llm = Mock(return_value=response)
-    result = huggingface_wrapper.generate_topic_name("test prompt")
+    result = huggingface_wrapper.generate_topic_name(make_prompt())
     assert result == ""
 
 
@@ -262,7 +261,7 @@ def test_huggingface_generate_topic_name_failure_malformed_json(
 def test_huggingface_generate_cluster_names_failure(huggingface_wrapper, mock_data):
     huggingface_wrapper.llm = Mock(side_effect=Exception("API Error"))
     result = huggingface_wrapper.generate_topic_cluster_names(
-        "test prompt", mock_data["old_names"]
+        make_prompt(), mock_data["old_names"]
     )
     assert result == mock_data["old_names"]
 
@@ -727,7 +726,7 @@ def test_litellm_generate_topic_name_success(litellm_wrapper, mock_data):
     response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
 
     with patch("litellm.completion", return_value=response):
-        result = litellm_wrapper.generate_topic_name("test prompt")
+        result = litellm_wrapper.generate_topic_name(make_prompt())
 
     validate_topic_name(result)
 
@@ -736,9 +735,7 @@ def test_litellm_generate_topic_name_success_system_prompt(litellm_wrapper, mock
     response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
 
     with patch("litellm.completion", return_value=response):
-        result = litellm_wrapper.generate_topic_name(
-            {"system": "system prompt", "user": "test prompt"}
-        )
+        result = litellm_wrapper.generate_topic_name(make_prompt())
 
     validate_topic_name(result)
 
@@ -748,7 +745,7 @@ def test_litellm_generate_cluster_names_success(litellm_wrapper, mock_data):
 
     with patch("litellm.completion", return_value=response):
         result = litellm_wrapper.generate_topic_cluster_names(
-            "test prompt",
+            make_prompt(),
             mock_data["old_names"],
         )
 
@@ -762,7 +759,7 @@ def test_litellm_generate_cluster_names_success_system_prompt(
 
     with patch("litellm.completion", return_value=response):
         result = litellm_wrapper.generate_topic_cluster_names(
-            {"system": "system prompt", "user": "test prompt"},
+            make_prompt(),
             mock_data["old_names"],
         )
 
@@ -777,7 +774,7 @@ def test_litellm_generate_cluster_names_success_on_malformed_mapping(
 
     with patch("litellm.completion", return_value=response):
         result = litellm_wrapper.generate_topic_cluster_names(
-            "test prompt",
+            make_prompt(),
             mock_data["old_names"],
         )
 
@@ -788,7 +785,7 @@ def test_litellm_generate_topic_name_failure_malformed_json(litellm_wrapper, moc
     response = MockLLMResponse.create_chat_response(mock_data["malformed_json"])
 
     with patch("litellm.completion", return_value=response):
-        result = litellm_wrapper.generate_topic_name("test prompt")
+        result = litellm_wrapper.generate_topic_name(make_prompt())
 
     assert result == ""
 
@@ -800,7 +797,7 @@ def test_litellm_topic_name_fail_fast_error(litellm_wrapper, error_class):
         side_effect=make_litellm_error(error_class),
     ):
         with pytest.raises(FailFastLLMError):
-            litellm_wrapper.generate_topic_name("test prompt")
+            litellm_wrapper.generate_topic_name(make_prompt())
 
 
 @pytest.mark.parametrize("error_class", LITELLM_FAIL_FAST)
@@ -815,7 +812,7 @@ def test_litellm_topic_cluster_names_fail_fast_error(
     ):
         with pytest.raises(FailFastLLMError):
             litellm_wrapper.generate_topic_cluster_names(
-                "test prompt",
+                make_prompt(),
                 mock_data["old_names"],
             )
 
@@ -830,7 +827,7 @@ def test_litellm_generate_topic_name_retry_exhausted_returns_empty(
         "litellm.completion",
         side_effect=[make_litellm_error(error_class) for _ in range(3)],
     ) as mock_completion:
-        result = litellm_wrapper.generate_topic_name("test prompt")
+        result = litellm_wrapper.generate_topic_name(make_prompt())
 
     assert result == ""
     assert mock_completion.call_count == 3
@@ -848,7 +845,7 @@ def test_litellm_generate_cluster_names_retry_exhausted_returns_old_names(
         side_effect=[make_litellm_error(error_class) for _ in range(3)],
     ) as mock_completion:
         result = litellm_wrapper.generate_topic_cluster_names(
-            "test prompt",
+            make_prompt(),
             mock_data["old_names"],
         )
 
@@ -901,8 +898,7 @@ def test_litellm_system_prompt_probe_falls_back_and_caches(litellm_wrapper, mock
         side_effect=[unsupported_error, good_response],
     ) as mock_completion:
         result = litellm_wrapper._call_llm_with_system_prompt(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -921,8 +917,7 @@ def test_litellm_system_prompt_cached_false_flattens_immediately(
 
     with patch("litellm.completion", return_value=good_response) as mock_completion:
         litellm_wrapper._call_llm_with_system_prompt(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -941,8 +936,7 @@ def test_litellm_system_prompt_probe_success_caches_true(
 
     with patch("litellm.completion", return_value=good_response):
         result = litellm_wrapper._call_llm_with_system_prompt(
-            system_prompt="system",
-            user_prompt="user",
+            {"system": "system", "user": "user"},
             temperature=0.4,
             max_tokens=20,
         )
@@ -960,7 +954,7 @@ def test_litellm_namer_temperature_override_is_used(litellm_wrapper, mock_data):
     response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
 
     with patch("litellm.completion", return_value=response) as mock_completion:
-        result = wrapper.generate_topic_name("test prompt", temperature=0.9)
+        result = wrapper.generate_topic_name(make_prompt(), temperature=0.9)
 
     assert mock_completion.call_args.kwargs["temperature"] == 0.0
     validate_topic_name(result)
@@ -1074,7 +1068,7 @@ def test_litellm_namer_generate_topic_name_uses_instance_default(
 
     with patch("litellm.completion", return_value=good_response) as mock_completion:
         litellm_wrapper.generate_topic_name(
-            "test prompt",
+            make_prompt(),
             # max_tokens not specified, should use instance default
         )
 
@@ -1095,7 +1089,7 @@ def test_litellm_namer_generate_topic_name_override_with_explicit_max_tokens(
 
     with patch("litellm.completion", return_value=good_response) as mock_completion:
         litellm_wrapper.generate_topic_name(
-            "test prompt", max_tokens=100  # explicit override
+            make_prompt(), max_tokens=100  # explicit override
         )
 
     # Check that the explicit value was used, not the instance default
@@ -1117,7 +1111,7 @@ def test_litellm_namer_generate_cluster_names_uses_instance_default(
 
     with patch("litellm.completion", return_value=good_response) as mock_completion:
         litellm_wrapper.generate_topic_cluster_names(
-            "test prompt",
+            make_prompt(),
             mock_data["old_names"],
             # max_tokens not specified, should use instance default
         )
@@ -1141,7 +1135,7 @@ def test_litellm_namer_generate_cluster_names_override_with_explicit_max_tokens(
 
     with patch("litellm.completion", return_value=good_response) as mock_completion:
         litellm_wrapper.generate_topic_cluster_names(
-            "test prompt", mock_data["old_names"], max_tokens=512  # explicit override
+            make_prompt(), mock_data["old_names"], max_tokens=512  # explicit override
         )
 
     # Check that the explicit value was used, not the instance default

--- a/toponymy/tests/test_prompt_construction.py
+++ b/toponymy/tests/test_prompt_construction.py
@@ -3,9 +3,11 @@ import numpy as np
 from toponymy.prompt_construction import topic_name_prompt
 from toponymy.templates import MULTILINGUAL_EN_FR_PROMPT_TEMPLATES, PROMPT_TEMPLATES
 from toponymy.prompt_construction import (
+    PROMPT_RENDERINGS,
     cluster_topic_names_for_renaming,
     find_threshold_for_max_cluster_size,
     distinguish_topic_names_prompt,
+    render_prompt,
 )
 from sentence_transformers import SentenceTransformer
 
@@ -50,7 +52,7 @@ def test_topic_name_prompt_no_subtopics():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_topic_name_prompt_with_subtopics():
@@ -97,7 +99,7 @@ def test_topic_name_prompt_with_subtopics():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_topic_name_prompt_with_subtopics_singleton_major_topic():
@@ -149,7 +151,7 @@ def test_topic_name_prompt_with_subtopics_singleton_major_topic():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_topic_name_prompt_with_empty_subtopics():
@@ -196,7 +198,7 @@ def test_topic_name_prompt_with_empty_subtopics():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_find_threshold_for_max_cluster_size():
@@ -379,7 +381,7 @@ def test_distinguish_topic_names_prompt_no_subtopics():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_distinguish_topic_names_prompt_with_subtopics():
@@ -438,7 +440,7 @@ def test_distinguish_topic_names_prompt_with_subtopics():
     print(prompt)
     print(expected_prompt)
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_distinguish_topic_names_prompt_with_single_topic():
@@ -483,7 +485,7 @@ def test_distinguish_topic_names_prompt_with_single_topic():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_distinguish_topic_names_prompt_with_empty_subtopics():
@@ -531,10 +533,10 @@ def test_distinguish_topic_names_prompt_with_empty_subtopics():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
-def test_topic_name_prompt_system_user_format():
+def test_topic_name_prompt_system_user_rendering():
     topic_index = 0
     layer_id = 1
     all_topic_names = [["Topic A"], ["Topic B"]]
@@ -587,7 +589,6 @@ def test_topic_name_prompt_system_user_format():
         object_description,
         corpus_description,
         summary_kind,
-        prompt_format="system_user",
     )
 
     assert prompts["system"] == expected_system_prompt
@@ -639,10 +640,10 @@ def test_topic_name_prompt_custom_template():
         exemplar_end_delimiter='"\n',
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
-def test_distinguish_topic_names_prompt_system_user_format():
+def test_distinguish_topic_names_prompt_system_user_rendering():
     topic_indices = np.array([0, 1])
     layer_id = 1
     all_topic_names = [["Topic A", "Topic B"], ["Topic C", "Topic D"]]
@@ -699,7 +700,6 @@ def test_distinguish_topic_names_prompt_system_user_format():
         object_description,
         corpus_description,
         summary_kind,
-        prompt_format="system_user",
     )
 
     assert prompts["system"] == expected_system_prompt
@@ -751,7 +751,7 @@ def test_distinguish_topic_names_prompt_custom_template():
         exemplar_end_delimiter='"\n',
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_distinguish_topic_names_prompt_very_specific_summary():
@@ -799,7 +799,7 @@ def test_distinguish_topic_names_prompt_very_specific_summary():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
 def test_topic_name_prompt_general_summary():
@@ -845,60 +845,73 @@ def test_topic_name_prompt_general_summary():
         summary_kind,
     )
 
-    assert prompt == expected_prompt
+    assert prompt["combined"] == expected_prompt
 
 
-def test_topic_name_prompt_invalid_format():
-    topic_index = 0
-    layer_id = 1
-    all_topic_names = [["Topic A"], ["Topic B"]]
-    exemplar_texts = [["Example text for Topic A"], ["Example text for Topic B"]]
-    keyphrases = [["keyphrase1", "keyphrase2"], ["keyphrase3", "keyphrase4"]]
-    subtopics = None
-    cluster_tree = None
-    object_description = "document"
-    corpus_description = "corpus"
-    summary_kind = "summary"
-
-    with pytest.raises(ValueError, match="Unsupported prompt_format"):
-        topic_name_prompt(
-            topic_index,
-            layer_id,
-            all_topic_names,
-            exemplar_texts,
-            keyphrases,
-            subtopics,
-            cluster_tree,
-            object_description,
-            corpus_description,
-            summary_kind,
-            prompt_format="invalid_format",
-        )
+def _simple_topic_name_prompt(**kwargs):
+    return topic_name_prompt(
+        0,
+        1,
+        [["Topic A"], ["Topic B"]],
+        [["Example text for Topic A"], ["Example text for Topic B"]],
+        [["keyphrase1", "keyphrase2"], ["keyphrase3", "keyphrase4"]],
+        None,
+        None,
+        "document",
+        "corpus",
+        "summary",
+        **kwargs,
+    )
 
 
-def test_distinguish_topic_names_prompt_invalid_format():
-    topic_indices = np.array([0, 1])
-    layer_id = 1
-    all_topic_names = [["Topic A", "Topic B"], ["Topic C", "Topic D"]]
-    exemplar_texts = [["Example text for Topic A"], ["Example text for Topic B"]]
-    keyphrases = [["keyphrase1", "keyphrase2"], ["keyphrase3", "keyphrase4"]]
-    subtopics = None
-    cluster_tree = None
-    object_description = "document"
-    corpus_description = "corpus"
-    summary_kind = "summary"
+def _simple_distinguish_topic_names_prompt(**kwargs):
+    return distinguish_topic_names_prompt(
+        np.array([0, 1]),
+        1,
+        [["Topic A", "Topic B"], ["Topic C", "Topic D"]],
+        [["Example text for Topic A"], ["Example text for Topic B"]],
+        [["keyphrase1", "keyphrase2"], ["keyphrase3", "keyphrase4"]],
+        None,
+        None,
+        "document",
+        "corpus",
+        "summary",
+        **kwargs,
+    )
 
-    with pytest.raises(ValueError, match="Unsupported prompt_format"):
-        distinguish_topic_names_prompt(
-            topic_indices,
-            layer_id,
-            all_topic_names,
-            exemplar_texts,
-            keyphrases,
-            subtopics,
-            cluster_tree,
-            object_description,
-            corpus_description,
-            summary_kind,
-            prompt_format="invalid_format",
-        )
+
+@pytest.mark.parametrize(
+    "make_prompt",
+    [_simple_topic_name_prompt, _simple_distinguish_topic_names_prompt],
+    ids=["topic_name", "distinguish_topic_names"],
+)
+def test_prompt_carries_every_rendering(make_prompt):
+    """A prompt carries every rendering, so the LLM wrapper can pick one."""
+    prompt = make_prompt()
+
+    assert set(prompt) == set(PROMPT_RENDERINGS)
+    assert all(isinstance(rendering, str) for rendering in prompt.values())
+    assert all(rendering for rendering in prompt.values())
+
+
+@pytest.mark.parametrize(
+    "make_prompt",
+    [_simple_topic_name_prompt, _simple_distinguish_topic_names_prompt],
+    ids=["topic_name", "distinguish_topic_names"],
+)
+def test_prompt_format_is_deprecated_and_ignored(make_prompt):
+    with pytest.warns(DeprecationWarning, match="prompt_format is deprecated"):
+        prompt = make_prompt(prompt_format="system_user")
+
+    assert prompt == make_prompt()
+
+
+def test_render_prompt_reports_a_missing_rendering():
+    partial_template_set = {
+        rendering: template
+        for rendering, template in PROMPT_TEMPLATES["layer"].items()
+        if rendering != "combined"
+    }
+
+    with pytest.raises(KeyError, match="missing the combined template"):
+        render_prompt(partial_template_set, {})

--- a/toponymy/tests/test_serialization.py
+++ b/toponymy/tests/test_serialization.py
@@ -139,7 +139,7 @@ def fitted_toponymy_newsgroups():
     )
     toponymy.embedding_vectors_ = embeddings
     toponymy.clusterable_vectors_ = projection
-    
+
     # Build topic_names and topic_sizes
     topic_names = []
     topic_sizes = []
@@ -157,10 +157,10 @@ def fitted_toponymy_newsgroups():
         toponymy.cluster_layers_[layer].keyphrases = keyphrases
         topic_names.append(layer_names)
         topic_sizes.append(layer_sizes)
-    
+
     toponymy.topic_names_ = topic_names
     toponymy.topic_sizes_ = topic_sizes
-    
+
     return toponymy, metadata
 
 
@@ -208,35 +208,35 @@ def test_topic_names():
 def test_topic_tree_property():
     """Test that TopicModel.topic_tree() method returns a valid TopicTree."""
     model = mock_data_model()
-    
+
     # Get the topic tree
     topic_tree = model.topic_tree()
-    
+
     # Verify it's a TopicTree instance
     assert isinstance(topic_tree, TopicTree)
-    
+
     # Verify it has the correct attributes
     assert topic_tree.tree == model.cluster_tree
     assert topic_tree.topics == model.topic_names
     assert topic_tree.topic_sizes == model.topic_sizes
     assert topic_tree.n_objects == model.embedding_vectors.shape[0]
-    
+
     # Verify it can be converted to string (print functionality)
     tree_string = str(topic_tree)
     assert "Topic tree:" in tree_string
     assert "Topic A" in tree_string
     assert "Topic B" in tree_string
     assert "Subtopic" in tree_string
-    
+
     # Verify it can be rendered to HTML
     html_output = topic_tree._repr_html_()
     assert '<div class="topic-tree">' in html_output
     assert "Topic A" in html_output
     assert "Topic B" in html_output
-    
+
     # Verify print method works
     topic_tree.print()  # Should not raise an exception
-    
+
     # Test with prune_duplicates parameter
     topic_tree_no_prune = model.topic_tree(prune_duplicates=False)
     assert isinstance(topic_tree_no_prune, TopicTree)
@@ -245,7 +245,7 @@ def test_topic_tree_property():
 def test_from_toponymy(fitted_toponymy_newsgroups, premade_topic_model_path):
     """Test that TopicModel.from_toponymy correctly extracts all properties including topic_sizes."""
     toponymy, metadata = fitted_toponymy_newsgroups
-    
+
     test_model = TopicModel.from_toponymy(toponymy, document_df=metadata)
     ## This doesn't seem to work on Azure, but it does work locally.
     # good_model = TopicModel.from_file(premade_topic_model_path)
@@ -256,35 +256,37 @@ def test_from_toponymy(fitted_toponymy_newsgroups, premade_topic_model_path):
     assert test_model.cluster_tree == toponymy.cluster_tree_
     assert len(test_model.topic_df) == n_topics
     assert len(test_model.document_df) == test_model.embedding_vectors.shape[0]
-    
+
     # Verify topic_sizes were properly serialized
     assert "size" in test_model.topic_df.columns, "Size column should exist in topic_df"
-    assert test_model.topic_sizes == toponymy.topic_sizes_, "Topic sizes should match the original"
+    assert (
+        test_model.topic_sizes == toponymy.topic_sizes_
+    ), "Topic sizes should match the original"
 
 
 def test_topic_tree_from_fitted_toponymy(fitted_toponymy_newsgroups):
     """Test that topic_tree() method works with models created from fitted Toponymy."""
     toponymy, metadata = fitted_toponymy_newsgroups
-    
+
     # Create TopicModel from fitted Toponymy
     model = TopicModel.from_toponymy(toponymy, document_df=metadata)
-    
+
     # Get the topic tree
     topic_tree = model.topic_tree()
-    
+
     # Verify it's a TopicTree instance
     assert isinstance(topic_tree, TopicTree)
-    
+
     # Verify it has the correct number of objects
     assert topic_tree.n_objects == model.embedding_vectors.shape[0]
-    
+
     # Verify topics match
     assert topic_tree.topics == model.topic_names
-    
+
     # Verify it can be converted to string
     tree_string = str(topic_tree)
     assert "Topic tree:" in tree_string
-    
+
     # Verify it can be rendered to HTML
     html_output = topic_tree._repr_html_()
     assert '<div class="topic-tree">' in html_output
@@ -294,7 +296,7 @@ def test_round_trip_zip_with_size_column():
     """Test zip serialization with size column (newer models with topic_sizes)."""
     path = "test_model_sizes.tm.zip"
     model = mock_data_model()
-    
+
     # Add size column to topic_df (simulating newer models)
     expected_sizes = []
     for layer_matrix in model.cluster_layers:
@@ -303,22 +305,22 @@ def test_round_trip_zip_with_size_column():
         else:
             sizes = layer_matrix.sum(axis=0).tolist()
         expected_sizes.append([int(s // 255) for s in sizes])
-    
+
     size_map = {}
     for layer_idx, layer_sizes in enumerate(expected_sizes):
         for cluster_idx, size in enumerate(layer_sizes):
             size_map[(layer_idx, cluster_idx)] = size
-    
+
     model.topic_df["size"] = model.topic_df.apply(
         lambda row: size_map.get((row["layer"], row["cluster"]), 0), axis=1
     )
-    
+
     model.to_file(path)
     model2 = model.from_file(path)
-    
+
     if os.path.exists(path):
         os.remove(path)
-    
+
     # is_equal checks everything including topic_sizes when size column exists
     assert is_equal(model, model2)
 
@@ -328,9 +330,9 @@ def test_round_trip_lance_with_size_column():
     path = "test_model_sizes_lance"
     if os.path.exists(path) and os.path.isdir(path):
         shutil.rmtree(path)
-    
+
     model = mock_data_model()
-    
+
     # Add size column to topic_df (simulating newer models)
     expected_sizes = []
     for layer_matrix in model.cluster_layers:
@@ -339,22 +341,22 @@ def test_round_trip_lance_with_size_column():
         else:
             sizes = layer_matrix.sum(axis=0).tolist()
         expected_sizes.append([int(s // 255) for s in sizes])
-    
+
     size_map = {}
     for layer_idx, layer_sizes in enumerate(expected_sizes):
         for cluster_idx, size in enumerate(layer_sizes):
             size_map[(layer_idx, cluster_idx)] = size
-    
+
     model.topic_df["size"] = model.topic_df.apply(
         lambda row: size_map.get((row["layer"], row["cluster"]), 0), axis=1
     )
-    
+
     model.to_lance(path)
     model2 = model.from_lance(path)
-    
+
     if os.path.exists(path) and os.path.isdir(path):
         shutil.rmtree(path)
-    
+
     # is_equal checks everything including topic_sizes when size column exists
     assert is_equal(model, model2)
 
@@ -362,7 +364,7 @@ def test_round_trip_lance_with_size_column():
 def test_topic_sizes_fallback_without_size_column():
     """Test that topic_sizes can be reconstructed from cluster_layers if size column is missing."""
     model = mock_data_model()
-    
+
     # Compute expected sizes from cluster_layers
     expected_sizes = []
     for layer_matrix in model.cluster_layers:
@@ -371,8 +373,10 @@ def test_topic_sizes_fallback_without_size_column():
         else:
             sizes = layer_matrix.sum(axis=0).tolist()
         expected_sizes.append([int(s // 255) for s in sizes])
-    
+
     # Access topic_sizes without size column (should use fallback)
     sizes = model.topic_sizes
-    
-    assert sizes == expected_sizes, "topic_sizes should be computed from cluster_layers as fallback"
+
+    assert (
+        sizes == expected_sizes
+    ), "topic_sizes should be computed from cluster_layers as fallback"

--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -115,20 +115,14 @@ def test_toponymy_resyncs_runtime_layer_config_for_prefit_clusterer(
     object_vectors,
     clusterable_vectors,
 ):
-    # Ensure this test uses a wrapper that supports system prompts
-    assert llm.supports_system_prompts is True
-
     # Pre-fit clusterer with old settings
     clusterer.fit(
         clusterable_vectors,
         object_vectors,
-        prompt_format="combined",
         exemplar_delimiters=["<<OLD>>", "<</OLD>>"],
         show_progress_bar=False,
         verbose=False,
     )
-
-    assert all(layer.prompt_format == "combined" for layer in clusterer.cluster_layers_)
 
     new_exemplar_delimiters = ["<EXAMPLE>", "</EXAMPLE>"]
 
@@ -147,10 +141,7 @@ def test_toponymy_resyncs_runtime_layer_config_for_prefit_clusterer(
 
     model.fit(all_sentences, object_vectors, clusterable_vectors)
 
-    # prompt_format should now reflect the wrapper capability
-    assert all(layer.prompt_format == "system_user" for layer in model.cluster_layers_)
-
-    # other runtime config should also be updated
+    # runtime config should be updated
     assert all(
         layer.exemplar_delimiters == new_exemplar_delimiters
         for layer in model.cluster_layers_
@@ -178,7 +169,6 @@ def test_toponymy_alternative_options(
     clusterer.fit(
         clusterable_vectors,
         object_vectors,
-        prompt_format="combined",
         object_to_text_function=lambda x: x,
     )
     model = Toponymy(
@@ -230,7 +220,6 @@ def test_toponymy_alternative_options_2(
     clusterer.fit(
         clusterable_vectors,
         object_vectors,
-        prompt_format="system_user",
         object_to_text_function=lambda x: x,
     )
     model = Toponymy(
@@ -377,7 +366,6 @@ def test_toponymy_async_ollama(
     clusterer.fit(
         clusterable_vectors,
         object_vectors,
-        prompt_format="system_user",
         object_to_text_function=lambda x: x,
     )
 
@@ -455,9 +443,7 @@ class MockNamer(LLMWrapper):
     def _call_llm(self, prompt, temperature, max_tokens):
         return self._next(max_tokens)
 
-    def _call_llm_with_system_prompt(
-        self, system_prompt, user_prompt, temperature, max_tokens
-    ):
+    def _call_llm_with_system_prompt(self, prompt, temperature, max_tokens):
         return self._next(max_tokens)
 
 

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -150,12 +150,6 @@ class Toponymy:
 
         return tags
 
-    def _effective_prompt_format(self) -> str:
-        """
-        Determine the effective prompt format based on the llm_wrapper's capabilities.
-        """
-        return "system_user" if self.llm_wrapper.supports_system_prompts else "combined"
-
     def _sync_layer_runtime_config(self) -> None:
         """
         Refresh wrapper-sensitive / run-sensitive settings on all cluster layers.
@@ -164,7 +158,6 @@ class Toponymy:
         llm_wrapper and prompt configuration for this run.
         """
         for layer in self.cluster_layers_:
-            layer.prompt_format = self._effective_prompt_format()
             layer.exemplar_delimiters = self.exemplar_delimiters
             layer.show_progress_bar = self.show_progress_bars
             layer.verbose = self.verbose
@@ -240,7 +233,6 @@ class Toponymy:
                 verbose=self.verbose,
                 show_progress_bar=self.show_progress_bars,
                 exemplar_delimiters=self.exemplar_delimiters,
-                prompt_format=self._effective_prompt_format(),
                 prompt_template=self.prompt_template,
             )
 


### PR DESCRIPTION
Part 1 of #184, opened as a draft. This is the call-path cleanup we agreed to land first; the JSON schema stacks on top of it in a second PR.

## What changes

Prompts were rendered as either a combined string or a system/user pair, and which one you got was decided by `Toponymy._effective_prompt_format` before any wrapper was reached, then threaded as `prompt_format` through the cluster layers into all three prompt builders. The wrappers then re-derived the same fact by type-switching on `isinstance(prompt, str)`, and everything below `generate_topic_name` destructured the dict into positional strings.

A prompt is now a dict carrying every rendering it has — `system`, `user` and `combined`, listed in `PROMPT_RENDERINGS` — and the wrapper selects one at call time from its own `supports_system_prompts`. This is option 1 from the issue thread: nothing outside the wrapper consults `supports_system_prompts`, `_effective_prompt_format` deletes cleanly, and no prompt text changes for anybody.

The whole prompt is passed down to `_call_llm` / `_call_llm_with_system_prompt` and their async equivalents, so a per-prompt payload reaches the request builder intact. That is the seam the schema PR needs, and there is a test asserting the whole dict arrives rather than just the rendering that gets used.

The async batch methods take a single `List[Dict]` in place of parallel `system_prompts` / `user_prompts` lists. This is the change that makes per-prompt payloads possible in a concurrent batch at all — with parallel lists there was no way to tell two concurrent calls apart, which is what made me think the schema couldn't ride on the prompt.

Prompt text is unchanged. The combined templates are separately maintained strings rather than concatenations of the other two (`system` opens "You are an expert **at** classifying", `combined` opens "You are an expert **of** classifying"), so rendering all three and letting the wrapper choose preserves exactly what every namer sent before. The cost is one extra Jinja render per prompt over parameters already computed.

## Details worth a reviewer's eye

- **`prompt_format`** is accepted and ignored with a `DeprecationWarning` on the three prompt builders and the `ClusterLayer` constructors, and is gone from `Toponymy`. `clustering.py` needed no change since it only forwards `**layer_kwargs`.
- **The `[!SKIP!]` sentinel stays a string.** A cluster that inherits its name from a single already-named child never reaches a wrapper, so dressing it up as a prompt would have bought nothing and touched eight call sites in `cluster_layer.py`. `make_prompts` is therefore `List[str | dict]`, where `str` means "not a prompt at all", and the docstrings say so.
- **The bare-string path through `generate_*` is gone.** A non-dict prompt, or one lacking the rendering the wrapper needs, raises `InvalidLLMInputError` naming the missing rendering. `connectivity_status` keeps its public string signature and wraps the probe internally.
- **Custom `prompt_template` sets must now supply all three renderings.** All three shipped sets already do. A missing one is reported by name rather than surfacing as a bare `KeyError`.
- **Legacy namers** (LlamaCpp, HuggingFace, vLLM, and the Cohere/Anthropic/Azure batch wrappers) change by one destructuring line per method, per your "grab the string off the prompt dict" instruction — adjusted for option 1, so a namer that can't do system prompts reads `prompt["combined"]` rather than `prompt["user"]`. No JSON schema support was added to them here; that keeps this diff reviewable and we can revisit per wrapper once the surface exists.
- **`submit_batch`** on the batch namers is untouched. It is a separate public escape hatch that already accepted `str | dict`, and it keeps working with the new prompts because it reads `system`/`user`.
- **Debug callbacks** now carry the whole prompt dict on both paths rather than a string on one and a reconstructed pair on the other. `prompt_type` still records which rendering was used.

## Testing

`uv run pytest toponymy/tests -v` passes locally: 549 passed, 5 skipped. Two pre-existing local gaps, both unrelated and both present on `main` before this branch: `test_notebook_tools.py` needs `nbformat` and the `llamacpp` tests need `llama_cpp`, neither of which is installed in my environment.

New coverage on the seam itself:

- a prompt carries every rendering, for both the naming and the disambiguation builder
- `make_prompts` produces prompts carrying every rendering
- the wrapper uses system/user when `supports_system_prompts` is true and combined when it is false, for both `generate_topic_name` and `generate_topic_cluster_names`, sync and async
- the whole prompt dict reaches `_call_*`, not just the rendering that gets used
- a non-dict prompt, and a prompt missing the needed rendering, raise `InvalidLLMInputError`
- `prompt_format` warns and is ignored on the builders and on `ClusterLayerText`
- a template set missing a rendering is reported by name

The three wrappers I cannot exercise (Cohere, Anthropic and Azure batch) are mechanical changes of the same shape as the ones that are covered; you offered to test those locally when this is ready.

## Not in this PR

The JSON schema itself, `supports_json_schema`, and the schema-shaped 400 handling all belong to the stacked PR. #186 (order-invariant parsing) and #185 (`temperature` rejected on `claude-sonnet-5`/`opus-5`) are separate.

Credit where it's due: bendavidsteel's #68 hit the failure mode that motivated all of this, on a fork, and reported it. That patch also carried parsing changes, which #186 now covers.
