### PR TITLE
Link Toponymy architecture documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ Toponymy
 
 More traditional documentation can be found at: https://toponymy.readthedocs.io/
 
+For an overview of Toponymy's internal design, see the `Toponymy Architecture <https://github.com/TutteInstitute/toponymy/wiki/Toponymy-Architecture>`_ wiki page.
+
 The package name Toponymy is derived from the Greek topos ‘place’ + onuma ‘name’.  Thus, the naming of places.  
 The goal of Toponymy is to put names to places in the space of information. This could be a corpus of documents,
 in which case Toponymy can be viewed as a topic naming library.  It could also be a collection of images, in which case

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,6 +63,9 @@ and a tour of some of the richer functionality and uses cases.
    embedding_wrappers
    cluster_layers
 
+For an overview of Toponymy's internal design and extension points, see the
+`Toponymy Architecture <https://github.com/TutteInstitute/toponymy/wiki/Toponymy-Architecture>`_ wiki page.
+
 .. toctree::
    :maxdepth: 1
    :caption: Examples:


### PR DESCRIPTION
Just a few simple edits to the README and index to help potential developers find the architecture docs on the wiki.