### PR TITLE
Fix the `ClusterLayerSummaryText` check

### DIFF
--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -1,3 +1,10 @@
+from unittest.mock import MagicMock
+from toponymy.cluster_layer import (
+    ClusterLayerSummaryText,
+    ClusterLayerText,
+)
+from toponymy.templates import PROMPT_TEMPLATES, SUMMARY_PROMPT_TEMPLATES
+
 from toponymy.toponymy import Toponymy
 from toponymy.llm_wrappers import (
     OllamaNamer,
@@ -497,3 +504,37 @@ def test_toponymy_with_mock_namer(
         assert len(topic_name.strip()) > 0
     # Verify cluster structure
     assert len(model.cluster_layers_[1].cluster_labels) == len(cluster_label_vector)
+
+
+def test_toponymy_uses_summary_templates_for_summary_layer_class():
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=ClusterLayerSummaryText,
+        prompt_template=PROMPT_TEMPLATES,
+    )
+
+    assert model.prompt_template == SUMMARY_PROMPT_TEMPLATES
+
+
+def test_toponymy_uses_default_templates_for_regular_layer_class():
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=ClusterLayerText,
+    )
+
+    assert model.prompt_template == PROMPT_TEMPLATES
+
+
+def test_toponymy_does_not_override_custom_prompt_templates():
+    custom_template = {"custom": "template"}
+
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=ClusterLayerSummaryText,
+        prompt_template=custom_template,
+    )
+
+    assert model.prompt_template is custom_template

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -135,7 +135,7 @@ class Toponymy:
         # If the default prompt template is used, but the layer class is ClusterLayerSummaryText, it is
         # reasonable to switch to the summary prompt templates, if not, the user may be passing their own.
         if (
-            isinstance(layer_class, ClusterLayerSummaryText)
+            issubclass(layer_class, ClusterLayerSummaryText)
             and prompt_template == PROMPT_TEMPLATES
         ):
             self.prompt_template = SUMMARY_PROMPT_TEMPLATES


### PR DESCRIPTION
Replace a check that was always False with the intended check. 

`isinstance(layer_class, ClusterLayerSummaryText)` -> `issubclass(layer_class, ClusterLayerSummaryText)`

As `layer_class` is a class object, not an instance of the class. 

Added tests to check the intended logic path as well. 