### PR TITLE
Import NDArray from numpy.typing so import works on numpy 1.x

### DIFF
--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from numpy.typing import NDArray
 from tqdm.auto import tqdm
 import httpx
 from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
@@ -18,7 +19,7 @@ class TextEmbedderProtocol(Protocol):
         show_progress_bar: Optional[bool],
         *args,
         **kwargs,
-    ) -> np.typing.NDArray[np.floating]: ...
+    ) -> NDArray[np.floating]: ...
 
 
 # Cohere


### PR DESCRIPTION
Fixes #189

`np.typing` is only resolvable as an attribute of the top level module on numpy 2, or after something else has already imported `numpy.typing`. With numpy 1.26 installed and nothing importing it first, the return annotation on `TextEmbedderProtocol.encode` blows up on `import toponymy` since it is evaluated when the Protocol body runs. Importing `NDArray` from `numpy.typing` directly avoids that and works on every numpy the project declares.

Checked with a fresh venv on numpy 1.26.4: `np.typing.NDArray` raises AttributeError there, `from numpy.typing import NDArray` works.