### PR TITLE
fix: import NDArray directly from numpy.typing

### DIFF
--- a/toponymy/embedding_wrappers.py
+++ b/toponymy/embedding_wrappers.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from numpy.typing import NDArray
 from tqdm.auto import tqdm
 import httpx
 from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
@@ -18,7 +19,7 @@ class TextEmbedderProtocol(Protocol):
         show_progress_bar: Optional[bool],
         *args,
         **kwargs,
-    ) -> np.typing.NDArray[np.floating]: ...
+    ) -> NDArray[np.floating]: ...
 
 
 # Cohere


### PR DESCRIPTION
Fixes #189

## Problem

`np.typing.XXX` is only accessible on numpy < 2.0 if `numpy.typing` has been explicitly imported earlier. The declared constraint `numpy>=1.21` admits numpy 1.x, where this Protocol annotation raises:

```
AttributeError: module 'numpy' has no attribute 'typing'
```

when evaluated at class-definition time.

Whether the crash manifests today depends on the installed dependency versions: recent scipy (>= 1.11, array-api compat layer) and scikit-learn (>= 1.7, vendored array_api_compat) happen to import `numpy.typing` at startup, which masks the problem. With older — but fully allowed — versions, `import toponymy` crashes.

## Fix

**File**: `toponymy/embedding_wrappers.py`

```diff
 import os
 import numpy as np
+from numpy.typing import NDArray
 from tqdm.auto import tqdm
```

```diff
-    ) -> np.typing.NDArray[np.floating]: ...
+    ) -> NDArray[np.floating]: ...
```

`numpy.typing` has been importable since numpy 1.20, so importing `NDArray` binds the name at module import time on every numpy version the constraint allows. The annotation then evaluates safely at class-definition time and stays resolvable by tools that inspect type hints later (`typing.get_type_hints`, Sphinx autodoc, etc.) — unlike a deferred string annotation, which would still fail on numpy 1.x when resolved.

## Verification

Full-environment reproductions (clean venvs, `pip install -e .` with the listed constraints):

| numpy | pandas | scipy | scikit-learn | python | `import toponymy` |
|-------|--------|-------|--------------|--------|-------------------|
| 1.26.4 | 3.0.5 | 1.17.1 | 1.9.0 | 3.12 | ✅ succeeds (masked by scipy/sklearn/pandas array-api imports) |
| 1.26.4 | 2.3.3 | 1.17.1 | 1.9.0 | 3.12 | ✅ succeeds (masked by scipy/sklearn; pandas 2.x does not protect) |
| **1.26.4** | **2.3.3** | **1.10.1** | **1.6.1** | **3.10** | ❌ **`AttributeError: module 'numpy' has no attribute 'typing'`** at `embedding_wrappers.py:21` (unfixed) |
| 1.26.4 | 2.3.3 | 1.10.1 | 1.6.1 | 3.10 | ✅ succeeds **with the fix applied** |

The crash row is a fully legal resolution of the declared constraints (`numpy>=1.21`, `pandas>=1.0`, `scikit-learn>=1.6`, `scipy` unpinned, `requires-python>=3.10`): scipy 1.10 predates its array-api compat layer, and scikit-learn 1.6 predates the vendored copy, so no dependency imports `numpy.typing` before the annotation evaluates.

Additional mechanism check on numpy 1.26.4: with the fix applied, both the module import and `typing.get_type_hints(TextEmbedderProtocol.encode)` succeed (the annotation resolves to `ndarray[Any, dtype[floating]]`). The earlier `from __future__ import annotations` variant also imported cleanly, but failed `get_type_hints` with `AttributeError: module 'numpy' has no attribute 'typing'` on numpy 1.x, since the deferred string annotation is still resolved by tooling later — which is why the PR now imports `NDArray` directly.

The change is annotation-only — no behavioral change.