### PR TITLE
Update check in `Toponymy` for `ClusterLayerSummaryText`

### DIFF
--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -528,15 +528,7 @@ def test_toponymy_does_not_override_custom_prompt_templates():
 
 
 def test_toponymy_uses_summary_templates_for_partial_summary_layer_class():
-    partial_layer_class = partial(
-        ClusterLayerSummaryText,
-        n_keyphrases=32,
-        keyphrase_diversify_alpha=3.0,
-        n_exemplars=32,
-        exemplars_diversify_alpha=3.0,
-        n_subtopics=32,
-        subtopic_diversify_alpha=3.0,
-    )
+    partial_layer_class = partial(ClusterLayerSummaryText, n_keyphrases=32)
 
     model = Toponymy(
         MagicMock(),
@@ -545,3 +537,26 @@ def test_toponymy_uses_summary_templates_for_partial_summary_layer_class():
     )
 
     assert model.prompt_template == SUMMARY_PROMPT_TEMPLATES
+
+
+def test_toponymy_accepts_partial_regular_layer_class():
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=partial(ClusterLayerText, n_keyphrases=32),
+    )
+
+    assert model.prompt_template == PROMPT_TEMPLATES
+
+
+def test_toponymy_accepts_non_class_layer_factory():
+    def make_layer(*args, **kwargs):
+        return ClusterLayerText(*args, **kwargs)
+
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=make_layer,
+    )
+
+    assert model.prompt_template == PROMPT_TEMPLATES

--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from functools import partial
 from toponymy.cluster_layer import (
     ClusterLayerSummaryText,
     ClusterLayerText,
@@ -524,3 +525,23 @@ def test_toponymy_does_not_override_custom_prompt_templates():
     )
 
     assert model.prompt_template is custom_template
+
+
+def test_toponymy_uses_summary_templates_for_partial_summary_layer_class():
+    partial_layer_class = partial(
+        ClusterLayerSummaryText,
+        n_keyphrases=32,
+        keyphrase_diversify_alpha=3.0,
+        n_exemplars=32,
+        exemplars_diversify_alpha=3.0,
+        n_subtopics=32,
+        subtopic_diversify_alpha=3.0,
+    )
+
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=partial_layer_class,
+    )
+
+    assert model.prompt_template == SUMMARY_PROMPT_TEMPLATES

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -134,8 +134,10 @@ class Toponymy:
 
         # If the default prompt template is used, but the layer class is ClusterLayerSummaryText, it is
         # reasonable to switch to the summary prompt templates, if not, the user may be passing their own.
+        base = getattr(layer_class, "func", layer_class)
         if (
-            issubclass(layer_class, ClusterLayerSummaryText)
+            isinstance(base, type)
+            and issubclass(base, ClusterLayerSummaryText)
             and prompt_template == PROMPT_TEMPLATES
         ):
             self.prompt_template = SUMMARY_PROMPT_TEMPLATES

--- a/uv.lock
+++ b/uv.lock
@@ -6005,7 +6005,7 @@ wheels = [
 
 [[package]]
 name = "toponymy"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "apricot-select" },


### PR DESCRIPTION
Fixes #204 

The fix in #193 was incomplete and triggered a failing `topic_summaries.ipynb` test in weekly notebook test run https://dev.azure.com/TutteInstitute/build-pipelines/_build/results?buildId=3821&view=results.

In particular, the change to make the check for `ClusterLayerSummaryText` work assumed a concrete class. The issue with that check is that it doesn't account for a wrapped version of the class to be passed in as in `topic_summaries.ipynb`.

The fix unwraps partial-wrapped layer factories before checking the underlying class, so that both `ClusterLayerSummaryText` and 
```
partial(
      ClusterLayerSummaryText,
      n_keyphrases=32,
      keyphrase_diversify_alpha=3.0,
      n_exemplars=32,
      exemplars_diversify_alpha=3.0,
      n_subtopics=32,
      subtopic_diversify_alpha=3.0,
  )
```
get checked correctly. 

