### PR TITLE
Accept a functools.partial as layer_class again

### DIFF
--- a/toponymy/tests/test_toponymy.py
+++ b/toponymy/tests/test_toponymy.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest.mock import MagicMock
 from toponymy.cluster_layer import (
     ClusterLayerSummaryText,
@@ -524,3 +525,36 @@ def test_toponymy_does_not_override_custom_prompt_templates():
     )
 
     assert model.prompt_template is custom_template
+
+
+def test_toponymy_accepts_partial_summary_layer_class():
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=partial(ClusterLayerSummaryText, n_keyphrases=32),
+    )
+
+    assert model.prompt_template == SUMMARY_PROMPT_TEMPLATES
+
+
+def test_toponymy_accepts_partial_regular_layer_class():
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=partial(ClusterLayerText, n_keyphrases=32),
+    )
+
+    assert model.prompt_template == PROMPT_TEMPLATES
+
+
+def test_toponymy_accepts_non_class_layer_factory():
+    def make_layer(*args, **kwargs):
+        return ClusterLayerText(*args, **kwargs)
+
+    model = Toponymy(
+        MagicMock(),
+        MagicMock(),
+        layer_class=make_layer,
+    )
+
+    assert model.prompt_template == PROMPT_TEMPLATES

--- a/toponymy/toponymy.py
+++ b/toponymy/toponymy.py
@@ -18,6 +18,8 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from typing import List, Any, Optional, Type, Dict, Tuple
+from functools import partial
+import inspect
 
 
 class Toponymy:
@@ -134,8 +136,14 @@ class Toponymy:
 
         # If the default prompt template is used, but the layer class is ClusterLayerSummaryText, it is
         # reasonable to switch to the summary prompt templates, if not, the user may be passing their own.
+        # layer_class may also be a functools.partial wrapping the class (to preset per-layer keyword
+        # arguments), so look through the partial before checking the class itself.
+        base_layer_class = (
+            layer_class.func if isinstance(layer_class, partial) else layer_class
+        )
         if (
-            issubclass(layer_class, ClusterLayerSummaryText)
+            inspect.isclass(base_layer_class)
+            and issubclass(base_layer_class, ClusterLayerSummaryText)
             and prompt_template == PROMPT_TEMPLATES
         ):
             self.prompt_template = SUMMARY_PROMPT_TEMPLATES


### PR DESCRIPTION
Fixes #204.

`Toponymy.__init__` checks whether `layer_class` is a `ClusterLayerSummaryText` subclass in order to switch to `SUMMARY_PROMPT_TEMPLATES` when the caller left the default templates in place. Since #193 that check is an `issubclass`, which raises when `layer_class` is a `functools.partial`, the pattern `doc/topic_summaries.ipynb` uses to preset per-layer keyword arguments.

This looks through a partial to the class it wraps before the subclass check, and guards with `inspect.isclass` so any other callable factory keeps the default templates rather than raising, which is the case the surrounding comment already describes ("the user may be passing their own").

Three tests alongside the ones from #193: a partial of `ClusterLayerSummaryText` gets the summary templates, a partial of `ClusterLayerText` keeps the defaults, and a plain factory function keeps the defaults. With this applied, `doc/topic_summaries.ipynb` passes `test_doc_notebook_has_openainamer` again; it fails on `main`.

black 26.5.1 has been run.
