### PR TITLE
Fix: Include toponymy.tools package in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ log_level = "INFO"
 
 [tool.setuptools]
 zip-safe = false
-packages = ["toponymy"]
+packages = ["toponymy", "toponymy.tools"]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
The toponymy.tools subpackage (added between 0.5.2 and 0.5.3) contains notebook testing utilities and is imported by llm_wrappers.py. However, it was not included in the setuptools packages configuration, causing ModuleNotFoundError when installing from a wheel distribution.

This fix adds 'toponymy.tools' to the packages list to ensure all subpackages are included when building distributions.