### PR TITLE
Drop temperature when the provider says the model rejects it (#185)

### DIFF
--- a/toponymy/llm_wrappers.py
+++ b/toponymy/llm_wrappers.py
@@ -1375,6 +1375,7 @@ try:
             self._resolved_use_json_object: bool | None = None  # set internally
             self.disable_system_prompts = disable_system_prompts
             self._system_prompt_capability: bool | None = None
+            self._sampling_params_capability: bool | None = None
             self.max_tokens_topic_name = max_tokens_topic_name
             self.max_tokens_cluster_names = max_tokens_cluster_names
             self.provider_kwargs = dict(provider_kwargs) if provider_kwargs else {}
@@ -1423,6 +1424,18 @@ try:
                 }
             ]
 
+        def _looks_like_unsupported_sampling_param_error(self, exc: Exception) -> bool:
+            message = str(exc).lower()
+            return "temperature" in message and any(
+                s in message
+                for s in (
+                    "deprecated",
+                    "not supported",
+                    "unsupported",
+                    "does not support",
+                )
+            )
+
         def _detect_json_object_support(self) -> bool:
             try:
                 supported = litellm.get_supported_openai_params(model=self.model)
@@ -1452,10 +1465,12 @@ try:
                 {
                     "model": self.model,
                     "messages": messages,
-                    "temperature": temperature,
                     "max_tokens": max_tokens,
                 }
             )
+            if self._sampling_params_capability is not False:
+                kwargs["temperature"] = temperature
+
             if self.api_key is not None:
                 kwargs["api_key"] = self.api_key
 
@@ -1473,13 +1488,36 @@ try:
             temperature: float,
             max_tokens: int,
         ) -> str:
-            response = litellm.completion(
-                **self._provider_kwargs(
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
+            try:
+                response = litellm.completion(
+                    **self._provider_kwargs(
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
                 )
-            )
+
+            except Exception as e:
+                if (
+                    self._sampling_params_capability is not None
+                    or not self._looks_like_unsupported_sampling_param_error(e)
+                ):
+                    raise
+
+                # Claude Opus 4.7 and later reject a non-default temperature
+                # with 400 "`temperature` is deprecated for this model."; retry
+                # without it and remember, so the rest of the run omits it too.
+                self._sampling_params_capability = False
+                response = litellm.completion(
+                    **self._provider_kwargs(
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
+                )
+
+            if self._sampling_params_capability is None:
+                self._sampling_params_capability = True
             return response.choices[0].message.content
 
         def _call_llm(
@@ -1679,6 +1717,7 @@ try:
             self._resolved_use_json_object: bool | None = None
             self.disable_system_prompts = disable_system_prompts
             self._system_prompt_capability: bool | None = None
+            self._sampling_params_capability: bool | None = None
             self.max_tokens_topic_name = max_tokens_topic_name
             self.max_tokens_cluster_names = max_tokens_cluster_names
             self.provider_kwargs = dict(provider_kwargs) if provider_kwargs else {}
@@ -1714,6 +1753,18 @@ try:
                 }
             ]
 
+        def _looks_like_unsupported_sampling_param_error(self, exc: Exception) -> bool:
+            message = str(exc).lower()
+            return "temperature" in message and any(
+                s in message
+                for s in (
+                    "deprecated",
+                    "not supported",
+                    "unsupported",
+                    "does not support",
+                )
+            )
+
         def _detect_json_object_support(self) -> bool:
             try:
                 supported = litellm.get_supported_openai_params(model=self.model)
@@ -1743,10 +1794,11 @@ try:
                 {
                     "model": self.model,
                     "messages": messages,
-                    "temperature": temperature,
                     "max_tokens": max_tokens,
                 }
             )
+            if self._sampling_params_capability is not False:
+                kwargs["temperature"] = temperature
 
             if self.api_key is not None:
                 kwargs["api_key"] = self.api_key
@@ -1766,13 +1818,36 @@ try:
             max_tokens: int,
         ) -> str:
             async with self.semaphore:
-                response = await litellm.acompletion(
-                    **self._provider_kwargs(
-                        messages=messages,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
+                try:
+                    response = await litellm.acompletion(
+                        **self._provider_kwargs(
+                            messages=messages,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                        )
                     )
-                )
+
+                except Exception as e:
+                    if (
+                        self._sampling_params_capability is not None
+                        or not self._looks_like_unsupported_sampling_param_error(e)
+                    ):
+                        raise
+
+                    # Claude Opus 4.7 and later reject a non-default temperature
+                    # with 400 "`temperature` is deprecated for this model.";
+                    # retry without it and remember, so the run omits it too.
+                    self._sampling_params_capability = False
+                    response = await litellm.acompletion(
+                        **self._provider_kwargs(
+                            messages=messages,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                        )
+                    )
+
+            if self._sampling_params_capability is None:
+                self._sampling_params_capability = True
             return response.choices[0].message.content
 
         async def _call_single_llm(

--- a/toponymy/tests/test_async_llm_wrappers.py
+++ b/toponymy/tests/test_async_llm_wrappers.py
@@ -890,6 +890,33 @@ async def test_async_litellm_system_prompt_cached_false_flattens_immediately(
 
 
 @pytest.mark.asyncio
+async def test_async_litellm_sampling_param_probe_falls_back_and_caches(
+    async_litellm_wrapper,
+    mock_data,
+):
+    unsupported_error = Exception("`temperature` is deprecated for this model.")
+    good_response = MockAsyncResponse.create_chat_response(
+        mock_data["valid_topic_name"]
+    )
+
+    with patch(
+        "litellm.acompletion",
+        new=AsyncMock(side_effect=[unsupported_error, good_response]),
+    ) as mock_acompletion:
+        result = await async_litellm_wrapper._acompletion_with_messages(
+            [{"role": "user", "content": "user"}],
+            temperature=0.4,
+            max_tokens=20,
+        )
+
+    assert result == mock_data["valid_topic_name"]
+    assert async_litellm_wrapper._sampling_params_capability is False
+    assert mock_acompletion.await_count == 2
+    assert mock_acompletion.await_args_list[0].kwargs["temperature"] == 0.4
+    assert "temperature" not in mock_acompletion.await_args_list[1].kwargs
+
+
+@pytest.mark.asyncio
 async def test_async_litellm_system_prompt_probe_success_caches_true(
     async_litellm_wrapper,
     mock_data,

--- a/toponymy/tests/test_llm_wrappers.py
+++ b/toponymy/tests/test_llm_wrappers.py
@@ -945,6 +945,79 @@ def test_litellm_system_prompt_probe_success_caches_true(
     assert litellm_wrapper._system_prompt_capability is True
 
 
+def test_litellm_sampling_param_probe_falls_back_and_caches(
+    litellm_wrapper,
+    mock_data,
+):
+    unsupported_error = Exception("`temperature` is deprecated for this model.")
+    good_response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
+
+    with patch(
+        "litellm.completion",
+        side_effect=[unsupported_error, good_response],
+    ) as mock_completion:
+        result = litellm_wrapper._completion_with_messages(
+            [{"role": "user", "content": "user"}],
+            temperature=0.4,
+            max_tokens=20,
+        )
+
+    assert result == mock_data["valid_topic_name"]
+    assert litellm_wrapper._sampling_params_capability is False
+    assert mock_completion.call_count == 2
+    assert mock_completion.call_args_list[0].kwargs["temperature"] == 0.4
+    assert "temperature" not in mock_completion.call_args_list[1].kwargs
+
+
+def test_litellm_sampling_param_cached_false_omits_temperature(
+    litellm_wrapper,
+    mock_data,
+):
+    litellm_wrapper._sampling_params_capability = False
+    good_response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
+
+    with patch("litellm.completion", return_value=good_response) as mock_completion:
+        litellm_wrapper._completion_with_messages(
+            [{"role": "user", "content": "user"}],
+            temperature=0.4,
+            max_tokens=20,
+        )
+
+    assert mock_completion.call_count == 1
+    assert "temperature" not in mock_completion.call_args.kwargs
+
+
+def test_litellm_sampling_param_probe_success_caches_true(litellm_wrapper, mock_data):
+    good_response = MockLLMResponse.create_chat_response(mock_data["valid_topic_name"])
+
+    with patch("litellm.completion", return_value=good_response) as mock_completion:
+        result = litellm_wrapper._completion_with_messages(
+            [{"role": "user", "content": "user"}],
+            temperature=0.4,
+            max_tokens=20,
+        )
+
+    assert result == mock_data["valid_topic_name"]
+    assert litellm_wrapper._sampling_params_capability is True
+    assert mock_completion.call_args.kwargs["temperature"] == 0.4
+
+
+def test_litellm_unrelated_error_is_not_retried_without_temperature(litellm_wrapper):
+    with patch(
+        "litellm.completion",
+        side_effect=Exception("rate limit exceeded"),
+    ) as mock_completion:
+        with pytest.raises(Exception, match="rate limit exceeded"):
+            litellm_wrapper._completion_with_messages(
+                [{"role": "user", "content": "user"}],
+                temperature=0.4,
+                max_tokens=20,
+            )
+
+    assert mock_completion.call_count == 1
+    assert litellm_wrapper._sampling_params_capability is None
+
+
 def test_litellm_namer_temperature_override_is_used(litellm_wrapper, mock_data):
     wrapper = LiteLLMNamer(
         api_key="dummy",


### PR DESCRIPTION

Implements option 2 from #185 — *"Catch this specific `invalid_request_error` and retry once
without `temperature`, caching the result on the wrapper. That mirrors the existing
`_looks_like_unsupported_system_prompt_error` probe, so the pattern is already in the file and
already tested."*

## What breaks

`LiteLLMNamer._provider_kwargs` sets `"temperature"` unconditionally
(`toponymy/llm_wrappers.py:1455`), at `generate_topic_name`'s default of `0.4` (`:500`).
`claude-sonnet-5` returns a 400 before generating anything, verbatim from the run record:

```json
{"message": "`temperature` is deprecated for this model.",
 "status_code": 400, "type": "api_status_error"}
```

`BadRequestError` is in `LiteLLMNamer.FAIL_FAST_EXCEPTIONS` (`:1341-1347`) and `_should_retry`
skips it, so naming does not degrade — it aborts on the first cluster.

The from-model in the measurement below is this project's own shipped default:
`AnthropicNamer(model="claude-haiku-4-5-20251001")` (`:1866`). This is what happens to a stock
`AnthropicNamer()` user the day they change one model string.

## Versions

| | |
|---|---|
| models | `claude-haiku-4-5-20251001` (baseline) → `claude-sonnet-5` (candidate) |
| endpoint | Anthropic Messages, `POST /v1/messages` |
| commit the reproduction pinned | `bcc46b86fc8ef1b791098497556f85678ec8cac0` (*"Merge pull request #207 from TutteInstitute/version-0.5.4"*) |
| this branch is based on | `bcc46b86fc8ef1b791098497556f85678ec8cac0` — the same commit; `main` had not moved when the branch was cut, so no rebase was needed and `toponymy/llm_wrappers.py` is byte-identical between the two |
| `litellm` in `uv.lock` | 1.85.0 (`uv.lock:2398`); `pyproject.toml` asks `>=1.83.10` |

## The patch

`toponymy/llm_wrappers.py`, +89/−14, plus 4 unit tests (+100).

It hardcodes no model list. It mirrors the capability-detection pattern already in this file
for system prompts (`_system_prompt_capability`,
`_looks_like_unsupported_system_prompt_error`, `_flatten_system_into_user`): send
`temperature` until the API says it is deprecated, then drop it, retry that one call, and
remember for the rest of the run.

```python
if self._sampling_params_capability is not False:
    kwargs["temperature"] = temperature
```

plus `_looks_like_unsupported_sampling_param_error` and a single retry in
`_completion_with_messages`. The same change is applied to
`AsyncLiteLLMNamer._acompletion_with_messages`, because the defect is identical there.

Four tests in the existing `patch("litellm.completion", ...)` style: fall back and cache;
cached-`False` omits the parameter with no probe call; the supported path still sends
`temperature=0.4` and caches `True`; and an unrelated error (`"rate limit exceeded"`) still
propagates on the first call with the capability left `None`.

## Before / after

Five prompts, one per cluster of this repo's own committed fixture
(`toponymy/tests/subtopic_objects.json`), grouped exactly as `conftest.py`'s
`cluster_label_vector` and `cluster_tree` group them. The system and user messages are this
repo's own `PROMPT_TEMPLATES["layer"]` rendered with `topic_name_prompt`'s own render params
(`prompt_construction.py:426-441`), with `document_type` and `corpus_description` taken from
`test_toponymy.py:48-49`. Each prompt ran 5 times per configuration; a case passes at ≥ 0.8 of
its reps and fails at ≤ 0.4. The checks are deterministic and are this repo's own: no API
error, and the answer must match `GET_TOPIC_NAME_REGEX` verbatim from `templates.py:14` —
the regex `llm_output_to_result` (`:284-293`) indexes into, so a miss raises `IndexError`,
burns all three `tenacity` attempts and leaves the topic unnamed.

| run | model, condition | cases | reps |
|---|---|---:|---:|
| baseline | `claude-haiku-4-5-20251001`, `temperature=0.4` | 5/5 pass | 25/25 |
| candidate | `claude-sonnet-5`, `temperature=0.4` | 0/5 pass | 0/25 |
| patched, broken cases | `claude-sonnet-5`, `temperature` omitted | 5/5 pass | 25/25 |
| patched, full suite | `claude-sonnet-5`, `temperature` omitted | 5/5 pass | 25/25 |

All 25 candidate reps ended in the 400 above, on the first API call, with `input_tokens: 0`
and no `resolved_model` — nothing was generated and nothing was billed. Each of the five cases
regressed at p = 0.00397 (one-sided Fisher exact, one-tailed on baseline vs candidate passes).
Verification re-ran the whole suite, not only the repaired cases: **0 previously-passing cases
broken** — with the caveat that all five cases were in the regression, so there was no
untouched case left to protect. That is the strongest claim this suite supports; it is not
evidence that nothing else in toponymy is affected.

An earlier run of the identical suite on 2026-09-05 produced the same numbers with the same
one-field change applied by hand (25/25 on `claude-sonnet-5`), so the patched arm rests on 50
paid reps, not 25.

What the two models actually answer (rep 1 of each case; both parse cleanly under
`GET_TOPIC_NAME_REGEX`, and `claude-haiku-4-5` wraps its JSON in a markdown fence while
`claude-sonnet-5` does not):

| cluster | `claude-haiku-4-5-20251001` | `claude-sonnet-5`, patched |
|---|---|---|
| technology | `Emerging Technologies` (0.75) | `Emerging Technology` (0.6) |
| health | `Wellness Health` (0.85) | `Health & Wellness` (0.6) |
| environment | `Environmental Sustainability` (0.92) | `Environment` (0.6) |
| education | `Educational Systems` (0.75) | `Education` (0.5) |
| economics | `Economic Principles` (0.75) | `Economics` (0.6) |

## A correction to the version floor agreed in the thread

The thread converged on *"bump the lock and set `drop_params=True`"* with a floor of
`litellm>=1.89.0`, from a bisect run against the live API. That bisect is right about where the
gate lands in the code. **It is not a safe floor for an installation whose model map is
local**, and toponymy is a library — its users pick the environment.

`AnthropicModelInfo._supports_sampling_params` (`llms/anthropic/common_utils.py`) resolves the
`supports_sampling_params` flag from the model map first and only then falls back to a name
check. Read from the published wheels (downloaded, never installed), in
`litellm/model_prices_and_context_window_backup.json`:

| litellm wheel | `claude-sonnet-5` in the bundled map | result for `temperature=0.4` |
|---|---|---|
| **1.85.0** (this repo's `uv.lock`) | absent; **0** entries carry the flag at all | no gate in `map_openai_params` — the value is forwarded unconditionally. `drop_params` is irrelevant: `temperature` is in `get_supported_openai_params`. **400.** |
| **1.89.0** (the floor the thread names) | **absent**; 28 entries carry the flag, none of them `claude-sonnet-5` or `claude-opus-5` | the gate exists, but with no map entry it falls through to the name check, which covers only `fable`, `opus-4-7`/`4.7`, `opus-4-8`/`4.8` — so `claude-sonnet-5` is reported as *supporting* sampling params. **400.** |
| **1.100.0** | present, `supports_sampling_params: false` (as does `claude-opus-5`; 61 entries carry the flag) | dropped with `drop_params=True`, or a clean client-side `UnsupportedParamsError` without it. **Works.** |

Why the live bisect and the wheels disagree, and why both are right: litellm fetches the model
map over the network at import unless `LITELLM_LOCAL_MODEL_COST_MAP` is set. A 1.89.0 install
with egress picks up today's map, which carries the flag, and the gate fires — exactly as
measured in the thread. A 1.89.0 install with `LITELLM_LOCAL_MODEL_COST_MAP=1`, in an
air-gapped environment, or behind a proxy that blocks the fetch, falls back to the bundled map
and sends `temperature` anyway. **The floor that holds without a network fetch is 1.100.0.**
The exact version at which `claude-sonnet-5` entered the bundled map was not bisected; only
these three wheels were read.

Two further differences, offered as reasons this patch might be worth keeping alongside the
version bump rather than instead of it:

1. `drop_params=True` drops **silently and globally**. Naming then runs at the provider's
   default sampling instead of the 0.4 this library chose, with no log line. This patch drops
   the same field only after the API has said so, and only for the model that said it — and
   `_sampling_params_capability` is inspectable afterwards.
2. `drop_params` is a litellm-wide setting, and this wrapper fronts 100+ providers.
   `_provider_kwargs` already merges user `provider_kwargs`, so a user can set `drop_params`
   themselves today — which makes it a workaround you can document immediately, independent of
   whichever fix lands.

## Limitations

- **This patch has not been compiled, imported or run in your toolchain.** No dependencies
  were installed and nothing from this repo was executed, so there is no `pytest` result
  behind it and the four new tests have **never been executed**. What did run offline:
  `black` 26.5.1 against your `[tool.black]` config (`--check` clean on all three changed
  files, before and after the change) and a Python syntactic parse of each. Please run CI
  before trusting the diff.
- **The retry path, the async twin and the sniffer's wording were not exercised against a live
  400.** What the runs verify is the *request shape*: 50 paid reps show that a Messages request
  with `max_tokens` and no `temperature` succeeds on `claude-sonnet-5` for this suite, and 25
  show the same request with `temperature: 0.4` is refused. The sniffer's target string is the
  API's own, recorded 25 times. A single silent first-call retry may not suit your fail-fast
  design; a check up front is a reasonable alternative and this diff is easy to reshape into
  one.
- **The before/after numbers come from a standalone reproduction, not from `toponymy` running
  in-process.** It sends the request `_provider_kwargs` builds — one system message, one user
  message, `max_tokens: 128`, `temperature: 0.4` — through the Anthropic Messages API
  directly. It does not exercise `tenacity`, `llm_output_to_result`, or any of `fit()`.
- **`cluster_keywords` was empty in the reproduction's prompts.** Keyphrases come from
  `KeyphraseBuilder` over a corpus, which the reproduction did not build, so its prompts are
  ~430 tokens where your own recorded run (`doc/debugging_llm_runs.ipynb`) shows ~9,261. Both
  models saw the identical shorter prompt, so it cannot create a difference between them.
- **One layer, one routine.** Only `generate_topic_name` at layer 1 was measured.
  `generate_topic_cluster_names`, the disambiguation prompt and topic summaries route through
  the same `_provider_kwargs` and this patch covers them, but they were not measured.
- **`BatchAnthropicNamer` is not fixed here.** As noted in the issue thread it builds its own
  request dicts against the Anthropic SDK and sends `"temperature"` unconditionally in three
  further places; that path is untouched by this diff and untested by this reproduction.
- **`claude-opus-5` was not run**, on cost grounds. The issue names it alongside
  `claude-sonnet-5`; litellm's 1.100.0 map marks both `supports_sampling_params: false`.
- **N = 5 per case per configuration.** 25/25 bounds that arm's true per-rep pass rate at
  86.7–100% (Wilson 95%); it is not a claim of perfection at scale.

Evidence: the reproduction was produced with [Upshift](https://github.com/Mechanism-world/upshift);
the full run records (every request, response and check result) are at
https://github.com/Mechanism-world/upshift/blob/main/reports/toponymy-upgrade.md.
